### PR TITLE
Give ability to use different parts of input in rules definitions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,15 @@ lazy val `decisions4s-examples` = (project in file("decisions4s-examples"))
   )
   .dependsOn(`decisions4s-core`, `decisions4s-dmn`, `decisions4s-cats-effect`, `decisions4s-dmn-to-image`)
 
+lazy val `decisions4s-examples-scala2` = (project in file("decisions4s-examples-scala-2"))
+  .settings(
+    scalaVersion   := "2.13.14",
+    libraryDependencies ++= testDeps,
+    publish / skip := true,
+    scalacOptions ++= Seq("-Ytasty-reader"),
+  )
+  .dependsOn(`decisions4s-core`)
+
 lazy val commonSettings = Seq(
   scalaVersion  := "3.4.2",
   scalacOptions ++= Seq("-no-indent"),

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val `decisions4s-examples` = (project in file("decisions4s-examples"))
   .dependsOn(`decisions4s-core`, `decisions4s-dmn`, `decisions4s-cats-effect`, `decisions4s-dmn-to-image`)
 
 lazy val commonSettings = Seq(
-  scalaVersion  := "3.3.3",
+  scalaVersion  := "3.4.2",
   scalacOptions ++= Seq("-no-indent"),
   libraryDependencies ++= testDeps,
   organization  := "org.business4s",

--- a/decisions4s-cats-effect/src/main/scala/decisions4s/cats/effect/MemoizingEvaluator.scala
+++ b/decisions4s-cats-effect/src/main/scala/decisions4s/cats/effect/MemoizingEvaluator.scala
@@ -57,14 +57,13 @@ class MemoizingEvaluator[Input[_[_]], Output[_[_]], F[_]: Concurrent: Async](val
     } yield (updating, refs)
   }
 
-  type FieldIdx = Int
   private def evaluateRule(rule: Rule[Input, Output], input: Input[F])(using EvaluationContext[Input]): F[Rule.Result[Input, Output]] = {
     type FBool[T] = F[Boolean]
     val evaluatedF: Input[FBool] = HKD.map2(rule.matching, input)(
       [t] =>
         (expr, fValue) =>
           {
-            expr match {
+            (expr: UnaryTest[t]) match {
               case UnaryTest.CatchAll => true.pure[F]
               case _                  => fValue.map(expr.evaluate)
             }

--- a/decisions4s-cats-effect/src/main/scala/decisions4s/cats/effect/MemoizingEvaluator.scala
+++ b/decisions4s-cats-effect/src/main/scala/decisions4s/cats/effect/MemoizingEvaluator.scala
@@ -1,40 +1,42 @@
 package decisions4s.cats.effect
 
-import cats.Applicative
-import cats.effect.Concurrent
-import cats.implicits.{catsSyntaxApplicativeId, toFunctorOps}
+import _root_.cats.effect.std.Dispatcher
+import _root_.cats.{Applicative, Monad}
+import _root_.cats.effect.{Async, Concurrent, Ref, Resource}
+import _root_.cats.implicits.{catsSyntaxApplicativeId, none, toFunctorOps}
 import cats.syntax.all.{toTraverseOps, given}
+import decisions4s.*
 import decisions4s.DecisionTable.HitPolicy
 import decisions4s.exprs.UnaryTest
 import decisions4s.internal.HKDUtils
-import decisions4s.*
 import shapeless3.deriving.Const
 
-import scala.collection.mutable
 import scala.util.chaining.scalaUtilChainingOps
 
-class MemoizingEvaluator[Input[_[_]], Output[_[_]], F[_]: Concurrent](val dt: DecisionTable[Input, Output, HitPolicy.First]) {
+class MemoizingEvaluator[Input[_[_]], Output[_[_]], F[_]: Concurrent: Async](val dt: DecisionTable[Input, Output, HitPolicy.First]) {
 
   import dt.given
 
   def evaluateFirst(in: Input[F]): F[EvalResult.First[Input, Output]] = {
     for {
-      memoized                              <- memoizeInput(in)
-      result                                <- evaluateRules(memoized)
-      (ruleResults, output, evaluatedFields) = result
-      evaluatedInputs                       <- collectEvaluatedFields(evaluatedFields, memoized)
+      memoized             <- memoizeInput(in)
+      (updating, refs)     <- collectValues(memoized)
+      result               <- evaluateRules(updating)
+      (ruleResults, output) = result
+      evaluatedInputs      <- collectEvaluatedFields(refs)
     } yield EvalResult(dt, evaluatedInputs, ruleResults, output)
   }
 
-  type EvaluatedFields     = Set[FieldIdx]
-  private type RulesResult = (List[Rule.Result[Input, Output]], Option[Output[Value]], EvaluatedFields)
+  private type RulesResult = (List[Rule.Result[Input, Output]], Option[Output[Value]])
   private def evaluateRules(in: Input[F]): F[RulesResult] = {
-    dt.rules.foldLeftM[F, RulesResult]((List(), None, Set())) {
-      case ((acc, None, evaluatedFieldsAcc), rule) =>
-        val (resultF, evaluatedFields) = evaluateRule(rule, in)
-        resultF.map(result => (acc :+ result, result.evaluationResult, evaluatedFieldsAcc ++ evaluatedFields))
-      case (acc, _)                                => acc.pure[F]
-    }
+    buildContext(in).use(ctx =>
+      dt.rules.foldLeftM[F, RulesResult]((List(), None)) {
+        case ((acc, None), rule) =>
+          val resultF = evaluateRule(rule, in)(using ctx)
+          resultF.map(result => (acc :+ result, result.evaluationResult))
+        case (acc, _)            => acc.pure[F]
+      },
+    )
   }
 
   // memoizes all the fields and reconstructs the input
@@ -45,34 +47,36 @@ class MemoizingEvaluator[Input[_[_]], Output[_[_]], F[_]: Concurrent](val dt: De
     memoized
   }
 
+  // collectValues
+  type OptionRef[T] = Ref[F, Option[T]]
+  private def collectValues(input: Input[F]): F[(Input[F], Input[OptionRef])] = {
+    val refsF: Input[[t] =>> F[OptionRef[t]]] = dt.inputHKD.pure([t] => () => Ref[F].of(none[t]))
+    for {
+      refs    <- sequence[Input, F, OptionRef](refsF)
+      updating = HKD.map2(input, refs)([t] => (fValue, ref) => Monad[F].flatTap(fValue)(value => ref.set(Some(value))))
+    } yield (updating, refs)
+  }
+
   type FieldIdx = Int
-  private def evaluateRule(rule: Rule[Input, Output], input: Input[F]): (F[Rule.Result[Input, Output]], Set[FieldIdx]) = {
+  private def evaluateRule(rule: Rule[Input, Output], input: Input[F])(using EvaluationContext[Input]): F[Rule.Result[Input, Output]] = {
     type FBool[T] = F[Boolean]
-    type Tup[T]   = Tuple2K[MatchingExpr, F][T]
-    val evaluatedFields: mutable.Set[FieldIdx] = mutable.Set()
-    var idx: FieldIdx                          = 0;
-    val evaluateMatch: Tup ~> FBool            = [t] =>
-      (tuple: Tup[t]) => {
-        val expr: MatchingExpr[t] = tuple._1
-        val fValue: F[t]          = tuple._2
-        val result: F[Boolean]    = expr match {
-          case UnaryTest.CatchAll => true.pure[F]
-          case _                  => {
-            evaluatedFields.add(idx)
-            fValue.map(expr.evaluate)
-          }
-        }
-        idx += 1;
-        result
-    }
-    val evaluatedF: Input[FBool]               = rule.matching.productK(input).mapK(evaluateMatch)
-    val sequenced                              = sequence[Input, F, Const[Boolean]](evaluatedF)
-    val result                                 = for {
+    val evaluatedF: Input[FBool] = HKD.map2(rule.matching, input)(
+      [t] =>
+        (expr, fValue) =>
+          {
+            expr match {
+              case UnaryTest.CatchAll => true.pure[F]
+              case _                  => fValue.map(expr.evaluate)
+            }
+          },
+    )
+    val sequenced                = sequence[Input, F, Const[Boolean]](evaluatedF)
+    val result                   = for {
       evaluated <- sequenced
       matches    = HKDUtils.collectFields(evaluated).foldLeft(true)(_ && _)
       evalResult = Option.when(matches)(rule.evaluateOutput())
     } yield Rule.Result(evaluated, evalResult)
-    result -> evaluatedFields.toSet
+    result
   }
 
   // Weird implementation of usual sequence/traverse. Collects all the fields, sequences them and reconstruct the case class
@@ -94,17 +98,26 @@ class MemoizingEvaluator[Input[_[_]], Output[_[_]], F[_]: Concurrent](val dt: De
       })
   }
 
-  private def collectEvaluatedFields(idxs: EvaluatedFields, in: Input[F]): F[Input[Option]] = {
-    var idx: FieldIdx = -1
-    type FOption[T] = F[Option[T]]
-    val keepEvaluated: F ~> FOption = [t] =>
-      (fValue: F[t]) => {
-        idx += 1
-        if (idxs.contains(idx)) fValue.map(_.some)
-        else None.pure[F]
-    }
-    val onlyEvaluated               = in.mapK(keepEvaluated)
-    sequence(onlyEvaluated)
+  private def collectEvaluatedFields(refs: Input[OptionRef]): F[Input[Option]] = {
+    sequence(refs.mapK([t] => ref => ref.get))
+  }
+
+  private def buildContext(input: Input[F]): Resource[F, EvaluationContext[Input]] = {
+    Dispatcher
+      .sequential[F]
+      .map(dispatcher => {
+        val variables: Input[[t] =>> Expr[Any, t]] =
+          HKD.map2(input, HKD.typedNames[Input])([t] => (fValue, name) => FVariable[t](name, fValue, dispatcher))
+        new EvaluationContext[Input] {
+          override def wholeInput: Input[ValueExpr] = variables
+        }
+      })
+  }
+
+  case class FVariable[T](name: String, value: F[T], dispatcher: Dispatcher[F]) extends Expr[Any, T] {
+    override def evaluate(in: Any): T = dispatcher.unsafeRunSync(value)
+
+    override def renderExpression: String = name
   }
 
 }

--- a/decisions4s-cats-effect/src/main/scala/decisions4s/cats/effect/package.scala
+++ b/decisions4s-cats-effect/src/main/scala/decisions4s/cats/effect/package.scala
@@ -1,13 +1,13 @@
 package decisions4s.cats
 
-import cats.effect.Concurrent
+import cats.effect.{Async, Concurrent}
 import decisions4s.DecisionTable.HitPolicy
 import decisions4s.{DecisionTable, EvalResult}
 
 package object effect {
 
   extension [Input[_[_]], Output[_[_]]](dt: DecisionTable[Input, Output, HitPolicy.First]) {
-    def evaluateFirstF[F[_]: Concurrent](in: Input[F]): F[EvalResult.First[Input, Output]] = {
+    def evaluateFirstF[F[_]: Concurrent: Async](in: Input[F]): F[EvalResult.First[Input, Output]] = {
       new MemoizingEvaluator(dt).evaluateFirst(in)
     }
   }

--- a/decisions4s-cats-effect/src/test/scala/decisions4s/cats/effect/MemoizedEvalTest.scala
+++ b/decisions4s-cats-effect/src/test/scala/decisions4s/cats/effect/MemoizedEvalTest.scala
@@ -29,28 +29,49 @@ class MemoizedEvalTest extends FunSuite {
     HitPolicy.First,
   )
 
-  test("first rule triggered") {
-    val (result, counters) = evaluate(Input(1, 0, 0))
+//  test("first rule triggered") {
+//    val (result, counters) = evaluate(Input(1, 0, 0))
+//    assertEquals(result.output.map(_.d), Some(1): Option[Int])
+//    assertEquals(counters, Input[Counter](1, 0, 0))
+//  }
+//
+//  test("second rule triggered") {
+//    val (result, counters) = evaluate(Input(-11, 1, 0))
+//    assertEquals(result.output.map(_.d), Some(2): Option[Int])
+//    assertEquals(counters, Input[Counter](1, 1, 0))
+//  }
+//
+//  test("third rule triggered") {
+//    val (result, counters) = evaluate(Input(-1, 0, 1))
+//    assertEquals(result.output.map(_.d), Some(3): Option[Int])
+//    assertEquals(counters, Input[Counter](1, 1, 1))
+//  }
+
+  test("wholeInput") {
+    val testTable: DecisionTable[Input, Output, HitPolicy.First] = DecisionTable(
+      rules = List(
+        Rule(
+          matching = Input(
+            a = it.catchAll,
+            b = it.catchAll,
+            c = wholeInput.b > 1,
+          ),
+          output = Output(wholeInput.c),
+        )
+      ),
+      "test",
+      HitPolicy.First,
+    )
+    val (result, counters) = evaluate(Input(0, 2, 1), testTable)
+    println(result.makeDiagnosticsString)
     assertEquals(result.output.map(_.d), Some(1): Option[Int])
-    assertEquals(counters, Input[Counter](1, 0, 0))
+    assertEquals(counters, Input[Counter](0, 1, 1))
   }
 
-  test("second rule triggered") {
-    val (result, counters) = evaluate(Input(-11, 1, 0))
-    assertEquals(result.output.map(_.d), Some(2): Option[Int])
-    assertEquals(counters, Input[Counter](1, 1, 0))
-  }
-
-  test("third rule triggered") {
-    val (result, counters) = evaluate(Input(-1, 0, 1))
-    assertEquals(result.output.map(_.d), Some(3): Option[Int])
-    assertEquals(counters, Input[Counter](1, 1, 1))
-  }
-
-  def evaluate(input: Input[Value]): (EvalResult.First[Input, Output], Input[Counter]) = {
+  def evaluate(input: Input[Value], table: DecisionTable[Input, Output, HitPolicy.First] = testTable): (EvalResult.First[Input, Output], Input[Counter]) = {
     import _root_.cats.effect.unsafe.implicits.given
     val (effectfulInput, getCounters) = createCountingInput(input)
-    val result                        = testTable.evaluateFirstF(effectfulInput).unsafeRunSync()
+    val result                        = table.evaluateFirstF(effectfulInput).unsafeRunSync()
     (result, getCounters())
   }
 

--- a/decisions4s-core/src/main/scala/decisions4s/DecisionTable.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/DecisionTable.scala
@@ -11,7 +11,7 @@ case class DecisionTable[Input[_[_]], Output[_[_]], HitPolicy <: DecisionTable.H
     hitPolicy: HitPolicy,
 )(using val inputHKD: HKD[Input], val outputHKD: HKD[Output]) {
 
-  private def evaluateRaw(in: Input[Value]): Seq[() => Rule.Result[Input, Output]] = {
+  private def evaluateRaw(in: Input[Value]): Seq[() => RuleResult[Input, Output]] = {
     given EvaluationContext[Input] = new EvaluationContext[Input] {
       override val wholeInput: Input[ValueExpr] = HKD.map2(in, HKD.typedNames[Input])([t] => (value, name) => Variable[t](name, value))
     }

--- a/decisions4s-core/src/main/scala/decisions4s/DecisionTable.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/DecisionTable.scala
@@ -90,7 +90,7 @@ object DecisionTable {
   }
 
   private def transformer[Input[_[_]], Output[_[_]]](
-      dt: DecisionTable[Input, Output, _],
+      dt: DecisionTable[Input, Output, ?],
       in: Input[Value],
   ): EvaluationResultTransformer[Input, Output] = dt.evaluateRaw(in).pipe(EvaluationResultTransformer(_, dt, in))
 

--- a/decisions4s-core/src/main/scala/decisions4s/DecisionTable.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/DecisionTable.scala
@@ -1,17 +1,22 @@
 package decisions4s
 
+import decisions4s.exprs.Variable
 import decisions4s.internal.EvaluationResultTransformer
 
 import scala.util.chaining.scalaUtilChainingOps
 
-case class DecisionTable[Input[_[_]]: HKD, Output[_[_]]: HKD, HitPolicy <: DecisionTable.HitPolicy](
+case class DecisionTable[Input[_[_]], Output[_[_]], HitPolicy <: DecisionTable.HitPolicy](
     rules: List[Rule[Input, Output]],
     name: String,
     hitPolicy: HitPolicy,
 )(using val inputHKD: HKD[Input], val outputHKD: HKD[Output]) {
 
-  private def evaluateRaw(in: Input[Value]): Seq[() => Rule.Result[Input, Output]] =
+  private def evaluateRaw(in: Input[Value]): Seq[() => Rule.Result[Input, Output]] = {
+    given EvaluationContext[Input] = new EvaluationContext[Input] {
+      override val wholeInput: Input[ValueExpr] = HKD.map2(in, HKD.typedNames[Input])([t] => (value, name) => Variable[t](name, value))
+    }
     rules.map(r => () => r.evaluate(in))
+  }
 
 }
 

--- a/decisions4s-core/src/main/scala/decisions4s/EvalResult.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/EvalResult.scala
@@ -16,7 +16,7 @@ import decisions4s.internal.DiagnosticsPrinter
 case class EvalResult[In[_[_]], Out[_[_]], +Output](
     table: DecisionTable[In, Out, ?],
     input: In[Option],
-    results: List[Rule.Result[In, Out]],
+    results: List[RuleResult[In, Out]],
     output: Output,
 ) {
 

--- a/decisions4s-core/src/main/scala/decisions4s/EvalResult.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/EvalResult.scala
@@ -14,7 +14,7 @@ import decisions4s.internal.DiagnosticsPrinter
   *   value produced by the table as a whole based on hit policy
   */
 case class EvalResult[In[_[_]], Out[_[_]], +Output](
-    table: DecisionTable[In, Out, _],
+    table: DecisionTable[In, Out, ?],
     input: In[Option],
     results: List[Rule.Result[In, Out]],
     output: Output,

--- a/decisions4s-core/src/main/scala/decisions4s/Expr.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/Expr.scala
@@ -1,6 +1,22 @@
 package decisions4s
 
-import decisions4s.exprs.{And, Between, Equal, GreaterThan, GreaterThanEqual, In, LessThan, LessThanEqual, Literal, NotEqual, Or, UnaryTest}
+import decisions4s.exprs.{
+  And,
+  Between,
+  Equal,
+  GreaterThan,
+  GreaterThanEqual,
+  In,
+  LessThan,
+  LessThanEqual,
+  Literal,
+  Minus,
+  Multiply,
+  NotEqual,
+  Or,
+  Plus,
+  UnaryTest,
+}
 
 trait Expr[-In, +Out] {
   def evaluate(in: In): Out
@@ -24,15 +40,19 @@ object Expr {
     def <(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]         = LessThan(lhs, rhs)
     def <=(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]        = LessThanEqual(lhs, rhs)
 
+    def +(rhs: Expr[I, O])(using Numeric[O]): Expr[I, O] = Plus(lhs, rhs)
+    def -(rhs: Expr[I, O])(using Numeric[O]): Expr[I, O] = Minus(lhs, rhs)
+    def *(rhs: Expr[I, O])(using Numeric[O]): Expr[I, O] = Multiply(lhs, rhs)
+
     def between(lowerBound: Expr[I, O], upperBound: Expr[I, O])(using Ordering[O]): Expr[I, Boolean] = Between(lhs, lowerBound, upperBound)
 
     infix def in(rhs: UnaryTest[O]): Expr[I, Boolean] = In(lhs, rhs)
   }
 
   extension [I](lhs: Expr[I, Boolean]) {
-    def &&(rhs: Expr[I, Boolean]): Expr[I, Boolean]  = And(lhs, rhs)
+    def &&(rhs: Expr[I, Boolean]): Expr[I, Boolean]        = And(lhs, rhs)
     infix def and(rhs: Expr[I, Boolean]): Expr[I, Boolean] = And(lhs, rhs)
-    def ||(rhs: Expr[I, Boolean]): Expr[I, Boolean]  = Or(lhs, rhs)
+    def ||(rhs: Expr[I, Boolean]): Expr[I, Boolean]        = Or(lhs, rhs)
     infix def or(rhs: Expr[I, Boolean]): Expr[I, Boolean]  = Or(lhs, rhs)
   }
 

--- a/decisions4s-core/src/main/scala/decisions4s/Expr.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/Expr.scala
@@ -1,6 +1,6 @@
 package decisions4s
 
-import decisions4s.exprs.{And, Between, Equal, GreaterThan, GreaterThanEqual, In, LessThan, LessThanEqual, NotEqual, Or, UnaryTest}
+import decisions4s.exprs.{And, Between, Equal, GreaterThan, GreaterThanEqual, In, LessThan, LessThanEqual, Literal, NotEqual, Or, UnaryTest}
 
 trait Expr[-In, +Out] {
   def evaluate(in: In): Out
@@ -10,23 +10,30 @@ trait Expr[-In, +Out] {
 object Expr {
 
   extension [I, O](lhs: Expr[I, O]) {
-    def ===(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean] = Equal(lhs, rhs)
-    def !==(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean] = NotEqual(lhs, rhs)
-    def >(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]   = GreaterThan(lhs, rhs)
-    def >=(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]  = GreaterThanEqual(lhs, rhs)
-    def <(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]   = LessThan(lhs, rhs)
-    def <=(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]  = LessThanEqual(lhs, rhs)
+    def equalsTo(rhs: Expr[I, O]): Expr[I, Boolean]              = Equal(lhs, rhs)
+    def ===(rhs: Expr[I, O]): Expr[I, Boolean]                   = Equal(lhs, rhs)
+    def equalsTo(rhs: O)(using LiteralShow[O]): Expr[I, Boolean] = Equal(lhs, Literal(rhs))
+    def ===(rhs: O)(using LiteralShow[O]): Expr[I, Boolean]      = Equal(lhs, Literal(rhs))
+
+    def !==(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]      = NotEqual(lhs, rhs)
+    def >(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]        = GreaterThan(lhs, rhs)
+    def >(rhs: O)(using Ordering[O], LiteralShow[O]): Expr[I, Boolean] = GreaterThan(lhs, Literal(rhs))
+
+    def >=(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]        = GreaterThanEqual(lhs, rhs)
+    def >=(rhs: O)(using Ordering[O], LiteralShow[O]): Expr[I, Boolean] = GreaterThanEqual(lhs, Literal(rhs))
+    def <(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]         = LessThan(lhs, rhs)
+    def <=(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]        = LessThanEqual(lhs, rhs)
 
     def between(lowerBound: Expr[I, O], upperBound: Expr[I, O])(using Ordering[O]): Expr[I, Boolean] = Between(lhs, lowerBound, upperBound)
 
-    def in(rhs: UnaryTest[O]): Expr[I, Boolean] = In(lhs, rhs)
+    infix def in(rhs: UnaryTest[O]): Expr[I, Boolean] = In(lhs, rhs)
   }
 
   extension [I](lhs: Expr[I, Boolean]) {
     def &&(rhs: Expr[I, Boolean]): Expr[I, Boolean]  = And(lhs, rhs)
-    def and(rhs: Expr[I, Boolean]): Expr[I, Boolean] = And(lhs, rhs)
+    infix def and(rhs: Expr[I, Boolean]): Expr[I, Boolean] = And(lhs, rhs)
     def ||(rhs: Expr[I, Boolean]): Expr[I, Boolean]  = Or(lhs, rhs)
-    def or(rhs: Expr[I, Boolean]): Expr[I, Boolean]  = Or(lhs, rhs)
+    infix def or(rhs: Expr[I, Boolean]): Expr[I, Boolean]  = Or(lhs, rhs)
   }
 
 }

--- a/decisions4s-core/src/main/scala/decisions4s/LiteralShow.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/LiteralShow.scala
@@ -16,6 +16,7 @@ object LiteralShow {
   given LiteralShow[Int]            = _.toString
   given LiteralShow[Long]           = _.toString
   given LiteralShow[Double]         = _.toString
+  given LiteralShow[BigDecimal]     = _.toString()
   given LiteralShow[String]         = x => s"\"$x\""
   given LiteralShow[LocalDate]      = temporal("yyyy-MM-dd")
   given LiteralShow[LocalTime]      = temporal("HH:mm:ss")

--- a/decisions4s-core/src/main/scala/decisions4s/RuleResult.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/RuleResult.scala
@@ -1,0 +1,8 @@
+package decisions4s
+
+import decisions4s.internal.HKDUtils.Const
+
+case class RuleResult[Input[_[_]], Output[_[_]]](
+    details: Input[Const[Boolean]],
+    evaluationResult: Option[Output[Value]],
+)

--- a/decisions4s-core/src/main/scala/decisions4s/exprs/UnaryTest.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/exprs/UnaryTest.scala
@@ -69,9 +69,6 @@ object UnaryTest extends LowPriorityUnaryTestConversion {
     override def renderExpression: String = expr.renderExpression
   }
 
-  implicit def oneOf[T](expr: Expr[T, Iterable[T]]): UnaryTest[T] = OneOf(expr)
-  implicit def equalTo[T](expr: Expr[T, T]): UnaryTest[T]         = EqualTo(expr)
-
   extension [I](lhs: UnaryTest[I]) {
     def unary_! : UnaryTest[I]              = Not(lhs)
     def ||(rhs: UnaryTest[I]): UnaryTest[I] = Or(Seq(lhs, rhs))

--- a/decisions4s-core/src/main/scala/decisions4s/exprs/base.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/exprs/base.scala
@@ -3,12 +3,12 @@ package decisions4s.exprs
 import decisions4s.{Expr, LiteralShow}
 
 case class Literal[T](v: T)(using show: LiteralShow[T]) extends Expr[Any, T] {
-  override def evaluate(in: Any): T         = v
+  override def evaluate(in: Any): T     = v
   override def renderExpression: String = show.show(v)
 }
 
 case class Input[T]() extends Expr[T, T] {
-  override def evaluate(in: T): T           = in
+  override def evaluate(in: T): T       = in
   override def renderExpression: String = "?"
 }
 
@@ -16,7 +16,7 @@ case class Comment[I, O](inner: Expr[I, O], comment: String) extends Expr[I, O] 
   override def evaluate(in: I): O = inner.evaluate(in)
 
   override def renderExpression: String = {
-    val lines      = comment.linesIterator.toList
+    val lines              = comment.linesIterator.toList
     val commentStr: String =
       if (lines.size == 1) comment.prependedAll("// ")
       else (List("/*") ++ lines.map(_.prependedAll(" * ")) ++ List(" */")).mkString("\n")
@@ -24,3 +24,15 @@ case class Comment[I, O](inner: Expr[I, O], comment: String) extends Expr[I, O] 
        |${inner.renderExpression}""".stripMargin
   }
 }
+
+case class Variable[T](name: String, value: T) extends Expr[Any, T] {
+  override def evaluate(in: Any): T = value
+  override def renderExpression: String = name
+}
+
+// used only for rendering
+case class VariableStub[T](name: String) extends Expr[Any, T] {
+  override def evaluate(in: Any): T = ???
+  override def renderExpression: String = name
+}
+

--- a/decisions4s-core/src/main/scala/decisions4s/exprs/math.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/exprs/math.scala
@@ -1,0 +1,23 @@
+package decisions4s.exprs
+
+import decisions4s.Expr
+
+// https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-numeric-expressions/
+
+
+class Plus[I, O](lhs: Expr[I, O], rhs: Expr[I, O])(using Numeric[O]) extends Expr[I, O] {
+  override def evaluate(in: I): O = Numeric[O].plus(lhs.evaluate(in), rhs.evaluate(in))
+  override def renderExpression: String = s"${lhs.renderExpression} + ${rhs.renderExpression}"
+}
+
+class Minus[I, O](lhs: Expr[I, O], rhs: Expr[I, O])(using Numeric[O]) extends Expr[I, O] {
+  override def evaluate(in: I): O = Numeric[O].minus(lhs.evaluate(in), rhs.evaluate(in))
+  override def renderExpression: String = s"${lhs.renderExpression} - ${rhs.renderExpression}"
+}
+
+class Multiply[I, O](lhs: Expr[I, O], rhs: Expr[I, O])(using Numeric[O]) extends Expr[I, O] {
+  override def evaluate(in: I): O = Numeric[O].times(lhs.evaluate(in), rhs.evaluate(in))
+  override def renderExpression: String = s"${lhs.renderExpression} * ${rhs.renderExpression}"
+}
+
+// no division and power for now because it can't be implemented generically

--- a/decisions4s-core/src/main/scala/decisions4s/internal/DiagnosticsPrinter.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/internal/DiagnosticsPrinter.scala
@@ -1,12 +1,12 @@
 package decisions4s.internal
 
 import decisions4s.exprs.VariableStub
-import decisions4s.{EvalResult, EvaluationContext, HKD, Rule, ValueExpr}
+import decisions4s.*
 import shapeless3.deriving.Const
 
 class DiagnosticsPrinter[Input[_[_]], Output[_[_]], Out](r: EvalResult[Input, Output, Out]) {
-  import r.{input, results, table}
   import r.table.given
+  import r.{input, results, table}
 
   private val inputNames: IndexedSeq[String]              = summon[HKD[Input]].fieldNames
   private val matchingExpressions: Vector[Vector[String]] = table.rules.toVector.map(rule => {
@@ -34,7 +34,7 @@ class DiagnosticsPrinter[Input[_[_]], Output[_[_]], Out](r: EvalResult[Input, Ou
       .mkString("\n")
   }
 
-  private def renderRule(rr: Rule.Result[Input, Output], idx: Int): String = {
+  private def renderRule(rr: RuleResult[Input, Output], idx: Int): String = {
     val fieldSatisfaction: Vector[Boolean] = HKDUtils.collectFields(rr.details).toVector
     val sign                               = if (rr.evaluationResult.isDefined) then "✓" else "✗"
     val output                             = rr.evaluationResult.map(x => s"== ${x.toString}").getOrElse("== ✗")

--- a/decisions4s-core/src/main/scala/decisions4s/internal/EvaluationResultTransformer.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/internal/EvaluationResultTransformer.scala
@@ -4,7 +4,7 @@ import decisions4s.*
 
 class EvaluationResultTransformer[Input[_[_]], Output[_[_]]](
     rawResults: Seq[() => Rule.Result[Input, Output]],
-    table: DecisionTable[Input, Output, _],
+    table: DecisionTable[Input, Output, ?],
     input: Input[Value],
 ) {
 

--- a/decisions4s-core/src/main/scala/decisions4s/internal/EvaluationResultTransformer.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/internal/EvaluationResultTransformer.scala
@@ -3,7 +3,7 @@ package decisions4s.internal
 import decisions4s.*
 
 class EvaluationResultTransformer[Input[_[_]], Output[_[_]]](
-    rawResults: Seq[() => Rule.Result[Input, Output]],
+    rawResults: Seq[() => RuleResult[Input, Output]],
     table: DecisionTable[Input, Output, ?],
     input: Input[Value],
 ) {
@@ -33,7 +33,7 @@ class EvaluationResultTransformer[Input[_[_]], Output[_[_]]](
   }
 
   def first(): EvalResult.First[Input, Output] = {
-    val (results, firstSatisfied) = rawResults.foldLeft((List.empty[Rule.Result[Input, Output]], Option.empty[Output[Value]])) {
+    val (results, firstSatisfied) = rawResults.foldLeft((List.empty[RuleResult[Input, Output]], Option.empty[Output[Value]])) {
       case ((acc, None), getResult)    =>
         val result = getResult()
 
@@ -67,7 +67,7 @@ class EvaluationResultTransformer[Input[_[_]], Output[_[_]]](
     result(raw, count)
   }
 
-  private def result[T](rawResults: List[Rule.Result[Input, Output]], output: T): EvalResult[Input, Output, T] = {
+  private def result[T](rawResults: List[RuleResult[Input, Output]], output: T): EvalResult[Input, Output, T] = {
     val toSome: Value ~> Option = [t] => (v: t) => Some(v): Option[t]
     import table.given
     EvalResult(table, input.mapK(toSome), rawResults, output)

--- a/decisions4s-core/src/main/scala/decisions4s/it.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/it.scala
@@ -11,8 +11,9 @@ object it {
   def value[T]: Expr[T, T] = Input()
 
   @targetName("equalsToOp")
-  def ===[T](value: T)(using LiteralShow[T]): UnaryTest[T]      = UnaryTest.EqualTo(Literal(value))
-  def equalsTo[T](value: T)(using LiteralShow[T]): UnaryTest[T] = UnaryTest.EqualTo(Literal(value))
+  def ===[T](value: T)(using LiteralShow[T]): UnaryTest[T]               = UnaryTest.EqualTo(Literal(value))
+  def equalsTo[T](value: T)(using LiteralShow[T]): UnaryTest[T]          = UnaryTest.EqualTo(Literal(value))
+  def equalsTo[T](value: Expr[T, T])(using LiteralShow[T]): UnaryTest[T] = UnaryTest.EqualTo(value)
 
   def equalsAnyOf[T](values: T*)(using LiteralShow[T]): UnaryTest[T] = Or(values.map(v => Literal(v)))
 

--- a/decisions4s-core/src/main/scala/decisions4s/it.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/it.scala
@@ -15,7 +15,8 @@ object it {
   def equalsTo[T](value: T)(using LiteralShow[T]): UnaryTest[T]          = UnaryTest.EqualTo(Literal(value))
   def equalsTo[T](value: Expr[T, T])(using LiteralShow[T]): UnaryTest[T] = UnaryTest.EqualTo(value)
 
-  def equalsAnyOf[T](values: T*)(using LiteralShow[T]): UnaryTest[T] = Or(values.map(v => Literal(v)))
+  def equalsAnyOf[T](values: T*)(using LiteralShow[T]): UnaryTest[T] = Or(values.map(it.equalsTo))
+  def equalsAnyOf[T](values: Expr[T, Iterable[T]]): UnaryTest[T]     = UnaryTest.OneOf(values)
 
   def >[T](value: T)(using LiteralShow[T], Ordering[T]): UnaryTest[T]  = Compare(Compare.Sign.`>`, Literal(value))
   def >[T](value: Expr[T, T])(using Ordering[T]): UnaryTest[T]         = Compare(Compare.Sign.`>`, value)
@@ -31,4 +32,6 @@ object it {
 
   def isTrue: Expr[Any, Boolean]  = True
   def isFalse: UnaryTest[Boolean] = UnaryTest.EqualTo(Literal(false))
+
+//  def isOneOf[T](values: Iterable[T]): UnaryTest[Boolean] = UnaryTest.OneOf(values)
 }

--- a/decisions4s-core/src/main/scala/decisions4s/package.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/package.scala
@@ -17,9 +17,11 @@ package object decisions4s {
     def wholeInput: In[ValueExpr]
   }
 
+  type OutputExpr[In[_[_]]]                  = [T] =>> EvaluationContext[In] ?=> OutputValue[T]
   opaque type OutputValue[T] <: Expr[Any, T] = Expr[Any, T]
   object OutputValue {
     implicit def toLiteral[T](t: T)(using LiteralShow[T]): OutputValue[T] = Literal(t)
+    implicit def fromExpr[T](expr: Expr[Any, T]): OutputValue[T]          = expr
   }
 
   def wholeInput[In[_[_]]](using ec: EvaluationContext[In]): In[ValueExpr] = ec.wholeInput

--- a/decisions4s-core/src/main/scala/decisions4s/package.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/package.scala
@@ -10,12 +10,18 @@ package object decisions4s {
   type Value[T]       = T
   type Description[T] = String
 
-  type ValueExpr[T]    = Expr[Any, T]
-  type MatchingExpr[T] = UnaryTest[T]
+  type ValueExpr[T]           = Expr[Any, T]
+  type MatchingExpr[In[_[_]]] = [T] =>> EvaluationContext[In] ?=> UnaryTest[T]
+
+  trait EvaluationContext[In[_[_]]] {
+    def wholeInput: In[ValueExpr]
+  }
 
   opaque type OutputValue[T] <: Expr[Any, T] = Expr[Any, T]
   object OutputValue {
     implicit def toLiteral[T](t: T)(using LiteralShow[T]): OutputValue[T] = Literal(t)
   }
+
+  def wholeInput[In[_[_]]](using ec: EvaluationContext[In]): In[ValueExpr] = ec.wholeInput
 
 }

--- a/decisions4s-core/src/test/scala/decisions4s/DecisionTableTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/DecisionTableTest.scala
@@ -190,14 +190,14 @@ class DecisionTableTest extends AnyFreeSpec {
 
   def buildExpectedResult[T](rulesHit: List[Boolean], output: T): EvalResult[Input, Output, T] = ???
 
-  def rawResults(hits: Boolean*): List[Rule.Result[Input, Output]] = {
+  def rawResults(hits: Boolean*): List[RuleResult[Input, Output]] = {
     given EvaluationContext[Input] = new EvaluationContext[Input] {
       override def wholeInput: Input[ValueExpr] = null // variables not sued in those tests
     }
 
     hits.zipWithIndex
       .map((wasHit, idx) =>
-        Rule.Result(
+        RuleResult(
           Input(wasHit),
           if (wasHit) Some(uniqueTestTable.rules(idx).evaluateOutput())
           else None,

--- a/decisions4s-core/src/test/scala/decisions4s/DecisionTableTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/DecisionTableTest.scala
@@ -1,8 +1,8 @@
 package decisions4s
 
-import munit.FunSuite
+import org.scalatest.freespec.AnyFreeSpec
 
-class DecisionTableTest extends FunSuite {
+class DecisionTableTest extends AnyFreeSpec {
 
   case class Input[F[_]](a: F[Int]) derives HKD
   case class Output[F[_]](c: F[Int]) derives HKD
@@ -26,140 +26,164 @@ class DecisionTableTest extends FunSuite {
     HitPolicy.Single,
   )
 
-  test("single - single matching rule") {
-    val result: EvalResult.Single[Input, Output]   = uniqueTestTable.evaluateSingle(Input(2))
-    assertEquals(result.output, Right(Some(Output[Value](1))))
-    assertEquals(result.results, rawResults(false, false, true))
+  "single - single matching rule" in {
+    val result: EvalResult.Single[Input, Output] = uniqueTestTable.evaluateSingle(Input(2))
+    assert(result.output == Right(Some(Output[Value](1))))
+    assert(result.results == rawResults(false, false, true))
   }
 
-  test("single - no matching rules") {
+  "single - no matching rules" in {
     val input  = Input[Value](0)
     val result = uniqueTestTable.evaluateSingle(input)
-    assertEquals(result.output, Right(None))
-    assertEquals(result.results, rawResults(false, false, false))
+    assert(result.output == Right(None))
+    assert(result.results == rawResults(false, false, false))
   }
 
-  test("single - multiple matching rules") {
-    val input                                      = Input[Value](3)
-    val result                                     = uniqueTestTable.evaluateSingle(input)
-    assertEquals(result.output, Left("not-single"): Either["not-single", Option[Output[Value]]])
-    assertEquals(result.results, rawResults(false, true, true))
+  "single - multiple matching rules" in {
+    val input  = Input[Value](3)
+    val result = uniqueTestTable.evaluateSingle(input)
+    assert(result.output == Left("not-single"))
+    assert(result.results == rawResults(false, true, true))
   }
 
   val anyTestTable: DecisionTable[Input, Output, HitPolicy.Distinct] = uniqueTestTable.copy(hitPolicy = HitPolicy.Distinct)
 
-  test("distinct - single matching rule") {
-    val result                                       = anyTestTable.evaluateDistinct(Input(2))
-    assertEquals(result.output, Right(Some(Output[Value](1))))
-    assertEquals(result.results, rawResults(false, false, true))
+  "distinct - single matching rule" in {
+    val result = anyTestTable.evaluateDistinct(Input(2))
+    assert(result.output == Right(Some(Output[Value](1))))
+    assert(result.results == rawResults(false, false, true))
   }
 
-  test("distinct - no matching rules") {
+  "distinct - no matching rules" in {
     val input  = Input[Value](0)
     val result = anyTestTable.evaluateDistinct(input)
-    assertEquals(result.output, Right(None))
-    assertEquals(result.results, rawResults(false, false, false))
+    assert(result.output == Right(None))
+    assert(result.results == rawResults(false, false, false))
   }
 
-  test("distinct - multiple matching rules with same value") {
+  "distinct - multiple matching rules with same value" in {
     val input  = Input[Value](3)
     val result = anyTestTable.evaluateDistinct(input)
-    assertEquals(result.output, Right(Some(Output[Value](1))))
-    assertEquals(result.results, rawResults(false, true, true))
+    assert(result.output == Right(Some(Output[Value](1))))
+    assert(result.results == rawResults(false, true, true))
   }
 
-  test("distinct - multiple matching rules with different values") {
+  "distinct - multiple matching rules with different values" in {
     val input  = Input[Value](4)
     val result = anyTestTable.evaluateDistinct(input)
-    assertEquals(result.output, Left("not-distinct"): Either["not-distinct", Option[Output[Value]]])
-    assertEquals(result.results, rawResults(true, true, true))
+    assert(result.output == Left("not-distinct"))
+    assert(result.results == rawResults(true, true, true))
   }
 
   val firstTestTable: DecisionTable[Input, Output, HitPolicy.First] = uniqueTestTable.copy(hitPolicy = HitPolicy.First)
 
-  test("first - no matching rules") {
+  "first - no matching rules" in {
     val result = firstTestTable.evaluateFirst(Input(1))
-    assertEquals(result.output, None)
-    assertEquals(result.results, rawResults(false, false, false))
+    assert(result.output == None)
+    assert(result.results == rawResults(false, false, false))
   }
-  test("first - 3rd rule") {
+  "first - 3rd rule" in {
     val result = firstTestTable.evaluateFirst(Input(2))
-    assertEquals(result.output, Some(Output[Value](1)))
-    assertEquals(result.results, rawResults(false, false, true))
+    assert(result.output == Some(Output[Value](1)))
+    assert(result.results == rawResults(false, false, true))
   }
-  test("first - 1st rule") {
+  "first - 1st rule" in {
     val result = firstTestTable.evaluateFirst(Input(4))
-    assertEquals(result.output, Some(Output[Value](2)))
-    assertEquals(result.results, rawResults(true))
+    assert(result.output == Some(Output[Value](2)))
+    assert(result.results == rawResults(true))
   }
 
   val collectTestTable: DecisionTable[Input, Output, HitPolicy.Collect] = uniqueTestTable.copy(hitPolicy = HitPolicy.Collect)
 
-  test("collect - no matching rules") {
+  "collect - no matching rules" in {
     val result = collectTestTable.evaluateCollect(Input(1))
-    assertEquals(result.output, List())
-    assertEquals(result.results, rawResults(false, false, false))
+    assert(result.output == List())
+    assert(result.results == rawResults(false, false, false))
   }
-  test("collect - all rules") {
+  "collect - all rules" in {
     val result = collectTestTable.evaluateCollect(Input(4))
-    assertEquals(result.output, List(Output[Value](2), Output[Value](1), Output[Value](1)))
-    assertEquals(result.results, rawResults(true, true, true))
+    assert(result.output == List(Output[Value](2), Output[Value](1), Output[Value](1)))
+    assert(result.results == rawResults(true, true, true))
   }
 
   val collectSumTable: DecisionTable[Input, Output, HitPolicy.CollectSum] = uniqueTestTable.copy(hitPolicy = HitPolicy.CollectSum)
 
-  test("collect sum - no matching rules") {
+  "collect sum - no matching rules" in {
     val result = collectSumTable.evaluateSum(Input(1))((a, b) => Output(a.c + b.c))
-    assertEquals(result.output, None)
-    assertEquals(result.results, rawResults(false, false, false))
+    assert(result.output == None)
+    assert(result.results == rawResults(false, false, false))
   }
-  test("collect sum - all matching rules") {
+  "collect sum - all matching rules" in {
     val result = collectSumTable.evaluateSum(Input(4))((a, b) => Output(a.c + b.c))
-    assertEquals(result.output, Some(Output[Value](4)))
-    assertEquals(result.results, rawResults(true, true, true))
+    assert(result.output == Some(Output[Value](4)))
+    assert(result.results == rawResults(true, true, true))
   }
 
   val collectMinTable: DecisionTable[Input, Output, HitPolicy.CollectMin] = uniqueTestTable.copy(hitPolicy = HitPolicy.CollectMin)
 
-  test("collect min - no matching rules") {
+  "collect min - no matching rules" in {
     given Ordering[Output[Value]] = Ordering.by(_.c)
     val result                    = collectMinTable.evaluateMin(Input(1))
-    assertEquals(result.output, None)
-    assertEquals(result.results, rawResults(false, false, false))
+    assert(result.output == None)
+    assert(result.results == rawResults(false, false, false))
   }
-  test("collect min - all matching rules") {
+  "collect min - all matching rules" in {
     given Ordering[Output[Value]] = Ordering.by(_.c)
     val result                    = collectMinTable.evaluateMin(Input(4))
-    assertEquals(result.output, Some(Output[Value](1)))
-    assertEquals(result.results, rawResults(true, true, true))
+    assert(result.output == Some(Output[Value](1)))
+    assert(result.results == rawResults(true, true, true))
   }
   val collectMaxTable: DecisionTable[Input, Output, HitPolicy.CollectMax] = uniqueTestTable.copy(hitPolicy = HitPolicy.CollectMax)
 
-  test("collect max - no matching rules") {
+  "collect max - no matching rules" in {
     given Ordering[Output[Value]] = Ordering.by(_.c)
     val result                    = collectMaxTable.evaluateMax(Input(1))
-    assertEquals(result.output, None)
-    assertEquals(result.results, rawResults(false, false, false))
+    assert(result.output == None)
+    assert(result.results == rawResults(false, false, false))
   }
-  test("collect max - all matching rules") {
+  "collect max - all matching rules" in {
     given Ordering[Output[Value]] = Ordering.by(_.c)
     val result                    = collectMaxTable.evaluateMax(Input(4))
-    assertEquals(result.output, Some(Output[Value](2)))
-    assertEquals(result.results, rawResults(true, true, true))
+    assert(result.output == Some(Output[Value](2)))
+    assert(result.results == rawResults(true, true, true))
   }
 
   val collectCountTable: DecisionTable[Input, Output, HitPolicy.CollectCount] = uniqueTestTable.copy(hitPolicy = HitPolicy.CollectCount)
 
-  test("collect count - no matching rules") {
+  "collect count - no matching rules" in {
     val result = collectCountTable.evaluateCount(Input(1))
-    assertEquals(result.output, 0)
-    assertEquals(result.results, rawResults(false, false, false))
+    assert(result.output == 0)
+    assert(result.results == rawResults(false, false, false))
   }
 
-  test("collect count - 2 matching rules") {
+  "collect count - 2 matching rules" in {
     val result = collectCountTable.evaluateCount(Input(3))
-    assertEquals(result.output, 2)
-    assertEquals(result.results, rawResults(false, true, true))
+    assert(result.output == 2)
+    assert(result.results == rawResults(false, true, true))
+  }
+
+  "wholeInput" in {
+    case class Input[F[_]](a: F[Int], b: F[Int]) derives HKD
+    case class Output[F[_]](a: F[String]) derives HKD
+    val table: DecisionTable[Input, Output, HitPolicy.Single.type] = DecisionTable(
+      rules = List(
+        Rule(
+          matching = Input(
+            a = ctx ?=> it.equalsTo(ctx.wholeInput.b),
+            b = it.equalsTo(wholeInput.a),
+          ),
+          output = Output("aa"),
+        ),
+      ),
+      "test",
+      HitPolicy.Single,
+    )
+
+    val result = table.evaluateSingle(Input[Value](1, 1))
+    assert(result.output == Right(Some(Output[Value]("aa"))))
+
+    val result2 = table.evaluateSingle(Input[Value](1, 2))
+    assert(result2.output == Right(None))
   }
 
   def buildExpectedResult[T](rulesHit: List[Boolean], output: T): EvalResult[Input, Output, T] = ???

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/AndTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/AndTest.scala
@@ -4,23 +4,21 @@ import decisions4s.exprs.TestUtils.checkExpression
 import munit.FunSuite
 
 class AndTest extends FunSuite {
-  class AndTest extends FunSuite {
-    test("basic") {
-      checkExpression(And(True, True), true)
-      checkExpression(True and True, true)
-      checkExpression(True && True, true)
+  test("basic") {
+    checkExpression(And(True, True), true)
+    checkExpression(True and True, true)
+    checkExpression(True && True, true)
 
-      checkExpression(And(True, False), false)
-      checkExpression(True and False, false)
-      checkExpression(True && False, false)
+    checkExpression(And(True, False), false)
+    checkExpression(True and False, false)
+    checkExpression(True && False, false)
 
-      checkExpression(And(False, True), false)
-      checkExpression(False and True, false)
-      checkExpression(False && True, false)
+    checkExpression(And(False, True), false)
+    checkExpression(False and True, false)
+    checkExpression(False && True, false)
 
-      checkExpression(And(False, False), false)
-      checkExpression(False and False, false)
-      checkExpression(False && False, false)
-    }
+    checkExpression(And(False, False), false)
+    checkExpression(False and False, false)
+    checkExpression(False && False, false)
   }
 }

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/EqualTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/EqualTest.scala
@@ -7,8 +7,10 @@ class EqualTest extends FunSuite {
   test("basic") {
     checkExpression(Equal(Literal(1), Literal(1)), true)
     checkExpression(Literal(1) === Literal(1), true)
+    checkExpression(Literal(1) === 1, true)
 
     checkExpression(Equal(Literal(1), Literal(2)), false)
     checkExpression(Literal(1) === Literal(2), false)
+    checkExpression(Literal(1) === 2, false)
   }
 }

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/InTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/InTest.scala
@@ -1,14 +1,15 @@
 package decisions4s.exprs
 
 import decisions4s.exprs.TestUtils.checkExpression
+import decisions4s.it
 import munit.FunSuite
 
 class InTest extends FunSuite {
   test("basic") {
-    checkExpression(In(Literal(1), Literal(1)), true)
-    checkExpression(Literal(1) in Literal(1), true)
+    checkExpression(In(Literal(1), it.equalsTo(1)), true)
+    checkExpression(Literal(1) in it.equalsTo(1), true)
 
-    checkExpression(In(Literal(2), Literal(1)), false)
-    checkExpression(Literal(2) in Literal(1), false)
+    checkExpression(In(Literal(2), it.equalsTo(1)), false)
+    checkExpression(Literal(2) in it.equalsTo(1), false)
   }
 }

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/MinusTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/MinusTest.scala
@@ -1,0 +1,11 @@
+package decisions4s.exprs
+
+import decisions4s.exprs.TestUtils.checkExpression
+import munit.FunSuite
+
+class MinusTest extends FunSuite {
+  test("basic") {
+    checkExpression(Minus(Literal(1), Literal(2)), -1)
+    checkExpression(Literal(1) - Literal(2), -1)
+  }
+}

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/MultiplyTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/MultiplyTest.scala
@@ -1,0 +1,11 @@
+package decisions4s.exprs
+
+import decisions4s.exprs.TestUtils.checkExpression
+import munit.FunSuite
+
+class MultiplyTest extends FunSuite {
+  test("basic") {
+    checkExpression(Multiply(Literal(3), Literal(4)), 12)
+    checkExpression(Literal(3) * Literal(4), 12)
+  }
+}

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/PlusTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/PlusTest.scala
@@ -1,0 +1,11 @@
+package decisions4s.exprs
+
+import decisions4s.exprs.TestUtils.checkExpression
+import munit.FunSuite
+
+class PlusTest extends FunSuite {
+  test("basic") {
+    checkExpression(Plus(Literal(1), Literal(2)), 3)
+    checkExpression(Literal(1) + Literal(2), 3)
+  }
+}

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/UnaryTestTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/UnaryTestTest.scala
@@ -8,20 +8,20 @@ import munit.FunSuite
 class UnaryTestTest extends FunSuite {
 
   test("bool conversion") {
-    val bool1: Expr[Any, Int]  = Literal(1)
+    val bool1: Expr[Int, Boolean]  = it.value[Int] > 1
     val unary1: UnaryTest[Int] = bool1
-    checkUnaryExpression(unary1, 1, true)
-    checkUnaryExpression(unary1, 2, false)
+    checkUnaryExpression(unary1, 2, true)
+    checkUnaryExpression(unary1, 1, false)
   }
 
-  test("comparison with boolean takes precedence over boolean conversion") {
+  test("comparison with boolean") {
     checkUnaryExpression(UnaryTest.EqualTo(True), false, false)
-    checkUnaryExpression((True: UnaryTest[Boolean]), false, false)
+    checkUnaryExpression((True: UnaryTest[Boolean]), true, true)
   }
 
   test("list conversion") {
     val list: Expr[Int, List[Int]] = Literal(List(1, 2, 3))
-    val unary: UnaryTest[Int]      = list
+    val unary: UnaryTest[Int]      = it.equalsAnyOf(list)
     checkUnaryExpression(unary, 1, true)
     checkUnaryExpression(it.equalsAnyOf(1, 2, 3), 1, true)
     checkUnaryExpression(unary, 2, true)
@@ -31,7 +31,7 @@ class UnaryTestTest extends FunSuite {
   }
   test("value conversion") {
     val value: Expr[Int, Int] = Literal(1)
-    val unary: UnaryTest[Int] = value
+    val unary: UnaryTest[Int] = it.equalsTo(value)
     checkUnaryExpression(unary, 1, true)
     checkUnaryExpression(it === 1, 1, true)
 
@@ -63,19 +63,16 @@ class UnaryTestTest extends FunSuite {
     checkUnaryExpression((it < 10) || (it > 50), 9, true)
     checkUnaryExpression((it < 10) || (it > 50), 20, false)
     checkUnaryExpression((it < 10) || (it > 50), 51, true)
-    checkUnaryExpression(Or(Seq(Literal(1), Literal(2))), 1, true)
-    checkUnaryExpression(Or(Seq(Literal(1), Literal(2))), 2, true)
-    checkUnaryExpression(Or(Seq(Literal(1), Literal(2))), 3, false)
   }
   test("negation") {
-    checkUnaryExpression(Not(Literal(1)), 1, false)
-    checkUnaryExpression(Not(Literal(1)), 2, true)
+    checkUnaryExpression(Not(it.equalsTo(1)), 1, false)
+    checkUnaryExpression(Not(it.equalsTo(1)), 2, true)
 
-    checkUnaryExpression(Not(Or(Seq(Literal(1), Literal(2)))), 1, false)
-    checkUnaryExpression(Not(Or(Seq(Literal(1), Literal(2)))), 2, false)
-    checkUnaryExpression(Not(Or(Seq(Literal(1), Literal(2)))), 3, true)
+    checkUnaryExpression(Not(Or(Seq(it.equalsTo(1), it.equalsTo(2)))), 1, false)
+    checkUnaryExpression(Not(Or(Seq(it.equalsTo(1), it.equalsTo(2)))), 2, false)
+    checkUnaryExpression(Not(Or(Seq(it.equalsTo(1), it.equalsTo(2)))), 3, true)
 
-    checkUnaryExpression(!(Literal(1): UnaryTest[Int]), 1, false)
+    checkUnaryExpression(! (it > 1), 2, false)
   }
 
 }

--- a/decisions4s-dmn-to-image/src/main/scala/decisions4s/dmn/image/DmnToImageConverter.scala
+++ b/decisions4s-dmn-to-image/src/main/scala/decisions4s/dmn/image/DmnToImageConverter.scala
@@ -12,9 +12,9 @@ import scala.util.Try
 
 /** Helper allowing to convert dmn XML into image through rendering in a browser (using dmn-js) and taking a screenshot.
   */
-class DmnToImageConverter(customDriver: Option[WebDriver with JavascriptExecutor with TakesScreenshot] = None) extends AutoCloseable {
+class DmnToImageConverter(customDriver: Option[WebDriver & JavascriptExecutor & TakesScreenshot] = None) extends AutoCloseable {
 
-  private val (driver, shouldClose): (WebDriver with JavascriptExecutor with TakesScreenshot, Boolean) =
+  private val (driver, shouldClose): (WebDriver & JavascriptExecutor & TakesScreenshot, Boolean) =
     customDriver.map(_ -> false).getOrElse(createDefaultDriver() -> true)
 
   def convertDiagram(dmnXml: String): Try[IArray[Byte]] = Try {
@@ -54,7 +54,7 @@ class DmnToImageConverter(customDriver: Option[WebDriver with JavascriptExecutor
     IArray.unsafeFromArray(os.toByteArray)
   }
 
-  private def createDefaultDriver(): WebDriver with JavascriptExecutor with TakesScreenshot = {
+  private def createDefaultDriver(): WebDriver & JavascriptExecutor & TakesScreenshot = {
     WebDriverManager.chromedriver().setup()
     val options = new ChromeOptions()
     // "--headless" seems to ignore "--windows-size"

--- a/decisions4s-examples-scala-2/src/main/scala/decisions4s/example/scala2/SimpleExample.scala
+++ b/decisions4s-examples-scala-2/src/main/scala/decisions4s/example/scala2/SimpleExample.scala
@@ -1,0 +1,19 @@
+package decisions4s.example.scala2
+
+import decisions4s._
+
+// we want to verify that decision tables can be _evaluated_ from scala 2
+// they still have to be deifned in scala 3
+case object SimpleExample {
+
+  case class Input[F[_]](a: F[Int])
+  case class Output[F[_]](b: F[Int])
+
+  def main(args: Array[String]): Unit = {
+    def decisionTable: DecisionTable[Input, Output, HitPolicy.First] = ???
+    val result: EvalResult.First[Input, Output]                      = DecisionTable.evaluateFirst(decisionTable)(Input[Value](1))
+    val diagnostics                                                  = result.makeDiagnosticsString
+    println(diagnostics)
+  }
+
+}

--- a/decisions4s-examples/src/main/scala/decisions4s/example/docs/DmnRenderingExample.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/docs/DmnRenderingExample.scala
@@ -11,7 +11,7 @@ object DmnRenderingExample {
   import decisions4s.dmn.*
   import org.camunda.bpm.model.dmn.{Dmn, DmnModelInstance}
 
-  val decisionTable: DecisionTable[Input, Output, _] = ???
+  val decisionTable: DecisionTable[Input, Output, ?] = ???
   val dmn: DmnModelInstance                          = DmnConverter.convert(decisionTable)
   val dmnXml: String                                 = Dmn.convertToString(dmn)
   // end_dmn_raw

--- a/decisions4s-examples/src/main/scala/decisions4s/example/docs/RulesExample.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/docs/RulesExample.scala
@@ -1,0 +1,23 @@
+package decisions4s.example.docs
+
+import decisions4s.{Expr, Rule, it, wholeInput}
+import decisions4s.*
+
+object RulesExample {
+
+  case class Input[F[_]](a: F[Int], b: F[Int])
+  case class Output[F[_]](c: F[Int])
+
+  // start_whole_input
+  Rule(
+    matching = Input(
+      a = it.equalsTo(wholeInput.b),
+      b = it.catchAll,
+    ),
+    output = Output(
+      c = wholeInput.a + wholeInput.b,
+    ),
+  )
+  // end_whole_input
+
+}

--- a/website/docs/features/hit-policies.md
+++ b/website/docs/features/hit-policies.md
@@ -4,49 +4,69 @@ sidebar_position: 4
 
 # Hit Policies
 
-`HitPolicy` defines how the output of the decision is computed. The possible pollicies are based
+`HitPolicy` defines how the output of the decision is computed from the results of particular rules.
+The available policies are based
 on [DMN Hit Policies](https://docs.camunda.org/manual/7.21/reference/dmn/decision-table/hit-policy/#collect-hit-policy)
 with small changes in naming for increased clarity. Each HitPolicy comes with dedicated evaluation method and dedicated
 return type.
 
 When in doubt we recommend using `Single` policy as a default, as this is the most restrictive one.
+Alternatively, `First` is often the most intuitive and easy to reason about.
+
+Each `HitPolicy` comes with dedicated evaluation method which returns a type specific to this policy.
 
 ### `HitPolicy.Single`
+
 Allows for only one rule to be satisfied. Maps to DMN `Unique` policy.
+
 ```scala file=./main/scala/decisions4s/example/docs/HitPoliciesExample.scala start=start_single end=end_single
 ```
 
 ### `HitPolicy.Distinct`
+
 Allows for multiple rules to be satisfied as long as they provide the same output. Maps to DMN `Any` policy.
+
 ```scala file=./main/scala/decisions4s/example/docs/HitPoliciesExample.scala start=start_distinct end=end_distinct
 ```
 
 ### `HitPolicy.First`
+
 First satisfied rule defines the result, others are ignored.
+
 ```scala file=./main/scala/decisions4s/example/docs/HitPoliciesExample.scala start=start_first end=end_first
 ```
 
 ### `HitPolicy.Collect`
+
 Outputs are collected into a list.
+
 ```scala file=./main/scala/decisions4s/example/docs/HitPoliciesExample.scala start=start_collect end=end_collect
 ```
 
 ### `HitPolicy.CollectSum`
+
 Outputs are combined together.
+
 ```scala file=./main/scala/decisions4s/example/docs/HitPoliciesExample.scala start=start_sum end=end_sum
 ```
 
 ### `HitPolicy.CollectMin`
+
 Minimal output is returned.
+
 ```scala file=./main/scala/decisions4s/example/docs/HitPoliciesExample.scala start=start_min end=end_min
 ```
 
 ### `HitPolicy.CollectMax`
+
 Maximal output is returned.
+
 ```scala file=./main/scala/decisions4s/example/docs/HitPoliciesExample.scala start=start_max end=end_max
 ```
 
 ### `HitPolicy.CollectCount`
+
 Number of satisfied rules is returned.
+
 ```scala file=./main/scala/decisions4s/example/docs/HitPoliciesExample.scala start=start_count end=end_count
 ```

--- a/website/docs/features/rules.md
+++ b/website/docs/features/rules.md
@@ -2,10 +2,13 @@
 sidebar_position: 3
 ---
 
-# Expressions
+# Wiriting Rules
 
-`Decisions4s` uses custom expressions for defining the matching logic for a given rule. Expression is just an object
-that can produce given `Out` based on `In` and statically render its string representation.
+`Decisions4s` uses custom expressions for defining the rules.
+Each rule has two parts: matching on the input and producing the output, both of which are defined using
+expressions.
+
+Expression is just an object that can produce given `Out` based on `In` and statically render its string representation.
 
 ```scala 
 trait Expr[-In, +Out] {
@@ -17,7 +20,7 @@ trait Expr[-In, +Out] {
 
 There is also a specialised type `UnaryTest[In] extends Expr[In, Boolean]` that allows us to closely follow
 the [FEEL model](https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-unary-tests/). This could be
-considered an internal complexity of the library, but all the rules have to be of type `UnaryTest[T]`.
+considered an internal complexity of the library, but all the matching logic has to be of type `UnaryTest[T]`.
 
 <!-- @formatter:off -->
 ```scala
@@ -28,14 +31,8 @@ case class Rule[Input[_[_]], Output[_[_]]](
 ```
 <!-- @formatter:on -->
 
-Implicit conversions between `Expr` and `UnaryTest` are provided based on the rules below.
-
-> A unary-tests expression returns true if one of the following conditions is fulfilled:
->
-> - The expression evaluates to true when the input value is applied to it.
-> - The expression evaluates to a list, and the input value is equal to at least one of the values in that list.
-> - The expression evaluates to a value, and the input value is equal to that value.
-> - The expression is equal to - (a dash).
+All the most common ways of building `UnaryTest`s are accesisble through `it` object.
+Implicit conversion between `Expr[T, Boolean]` is also defined.
 
 ## Built-in Expressions
 
@@ -69,3 +66,13 @@ can rely on a properly specified format instead of defining our own. Having said
 tables.
 
 User-defined expressions don't have to keep FEEL compatibility.
+
+## Accessing Other Inputs
+
+By default, all matching logic operates on the input it is defined for.
+To access other pieces of input one can use `wholeInput` method.
+The same way can be used to build the output value based on inputs.
+The example below compares `a` with `b` and returns their sum if they are equal.
+
+```scala file=./main/scala/decisions4s/example/docs/RulesExample.scala start=start_whole_input end=end_whole_input
+```

--- a/website/docs/other/scala2.md
+++ b/website/docs/other/scala2.md
@@ -17,14 +17,12 @@ We recommend the following approach:
 
 * Define a separate module `your-app-decisions` that will use Scala 3 and depend only on `Decisions4s`. Define your
   decisions there.
-  This is needed to leverage typeclass derivation that is based on macros that can be invoked only from Scala 3 module.
-
-  Alternatively the decisions can be defined directly in Scala 2 module, but this will require writing `HKD` instance by
-  hand or implementing a custom derivation mechanism.
+  This is needed
+  to leverage typeclass derivation that is based on macros that can be invoked only from Scala 3 module.
+  Also, rules definitions rely on context functions, which cannot be used from Scala 2.
 * Leverage
   the [ability to use Scala 3 from Scala 2](https://docs.scala-lang.org/scala3/guides/migration/compatibility-classpath.html#a-scala-213-module-can-depend-on-a-scala-3-artifact)
-  and `.dependsOn()` on the new module from the main one.
-  You can use all the features of Decisions4s (other than typeclass derivation) from within Scala 2 codebase.
+  and `.dependsOn()` on the new module from the main one. You can evaluate and visualize decisions from within Scala 2 codebase.
 * If you're using `decisions4s-cats-effect`, exclude the cats-effect dependency,
   to avoid the situation where both scala-3 and scala-2 versions land on the classpath. This is not entirely safe in
   theory but should work in practice.


### PR DESCRIPTION
This aims to cross-reference inputs across rule conditions. E.g. one might want to compare two input value. 

TODO: 

- [x]  docs
- [x] cats-effect tests