### PR TITLE
Remove input from expr definition

### DIFF
--- a/decisions4s-cats-effect/src/main/scala/decisions4s/cats/effect/MemoizingEvaluator.scala
+++ b/decisions4s-cats-effect/src/main/scala/decisions4s/cats/effect/MemoizingEvaluator.scala
@@ -105,16 +105,16 @@ class MemoizingEvaluator[Input[_[_]], Output[_[_]], F[_]: Concurrent: Async](val
     Dispatcher
       .sequential[F]
       .map(dispatcher => {
-        val variables: Input[[t] =>> Expr[Any, t]] =
+        val variables: Input[[t] =>> Expr[t]] =
           HKD.map2(input, HKD.typedNames[Input])([t] => (fValue, name) => FVariable[t](name, fValue, dispatcher))
         new EvaluationContext[Input] {
-          override def wholeInput: Input[ValueExpr] = variables
+          override def wholeInput: Input[Expr] = variables
         }
       })
   }
 
-  case class FVariable[T](name: String, value: F[T], dispatcher: Dispatcher[F]) extends Expr[Any, T] {
-    override def evaluate(in: Any): T = dispatcher.unsafeRunSync(value)
+  case class FVariable[T](name: String, value: F[T], dispatcher: Dispatcher[F]) extends Expr[T] {
+    override def evaluate: T = dispatcher.unsafeRunSync(value)
 
     override def renderExpression: String = name
   }

--- a/decisions4s-cats-effect/src/test/scala/decisions4s/cats/effect/MemoizedEvalTest.scala
+++ b/decisions4s-cats-effect/src/test/scala/decisions4s/cats/effect/MemoizedEvalTest.scala
@@ -57,18 +57,21 @@ class MemoizedEvalTest extends FunSuite {
             c = wholeInput.b > 1,
           ),
           output = Output(wholeInput.c),
-        )
+        ),
       ),
       "test",
       HitPolicy.First,
     )
-    val (result, counters) = evaluate(Input(0, 2, 1), testTable)
+    val (result, counters)                                       = evaluate(Input(0, 2, 1), testTable)
     println(result.makeDiagnosticsString)
     assertEquals(result.output.map(_.d), Some(1): Option[Int])
     assertEquals(counters, Input[Counter](0, 1, 1))
   }
 
-  def evaluate(input: Input[Value], table: DecisionTable[Input, Output, HitPolicy.First] = testTable): (EvalResult.First[Input, Output], Input[Counter]) = {
+  def evaluate(
+      input: Input[Value],
+      table: DecisionTable[Input, Output, HitPolicy.First] = testTable,
+  ): (EvalResult.First[Input, Output], Input[Counter]) = {
     import _root_.cats.effect.unsafe.implicits.given
     val (effectfulInput, getCounters) = createCountingInput(input)
     val result                        = table.evaluateFirstF(effectfulInput).unsafeRunSync()

--- a/decisions4s-core/src/main/scala/decisions4s/DecisionTable.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/DecisionTable.scala
@@ -13,7 +13,7 @@ case class DecisionTable[Input[_[_]], Output[_[_]], HitPolicy <: DecisionTable.H
 
   private def evaluateRaw(in: Input[Value]): Seq[() => RuleResult[Input, Output]] = {
     given EvaluationContext[Input] = new EvaluationContext[Input] {
-      override val wholeInput: Input[ValueExpr] = HKD.map2(in, HKD.typedNames[Input])([t] => (value, name) => Variable[t](name, value))
+      override val wholeInput: Input[Expr] = HKD.map2(in, HKD.typedNames[Input])([t] => (value, name) => Variable[t](name, value))
     }
     rules.map(r => () => r.evaluate(in))
   }

--- a/decisions4s-core/src/main/scala/decisions4s/Expr.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/Expr.scala
@@ -18,42 +18,48 @@ import decisions4s.exprs.{
   UnaryTest,
 }
 
-trait Expr[-In, +Out] {
-  def evaluate(in: In): Out
+trait Expr[+Out] {
+  def evaluate: Out
   def renderExpression: String
 }
 
 object Expr {
 
-  extension [I, O](lhs: Expr[I, O]) {
-    def equalsTo(rhs: Expr[I, O]): Expr[I, Boolean]              = Equal(lhs, rhs)
-    def ===(rhs: Expr[I, O]): Expr[I, Boolean]                   = Equal(lhs, rhs)
-    def equalsTo(rhs: O)(using LiteralShow[O]): Expr[I, Boolean] = Equal(lhs, Literal(rhs))
-    def ===(rhs: O)(using LiteralShow[O]): Expr[I, Boolean]      = Equal(lhs, Literal(rhs))
+  extension [O](lhs: Expr[O]) {
+    def equalsTo(rhs: Expr[O]): Expr[Boolean]                 = Equal(lhs, rhs)
+    def ===(rhs: Expr[O]): Expr[Boolean]                      = Equal(lhs, rhs)
+    def equalsTo(rhs: O)(using LiteralShow[O]): Expr[Boolean] = Equal(lhs, Literal(rhs))
+    def ===(rhs: O)(using LiteralShow[O]): Expr[Boolean]      = Equal(lhs, Literal(rhs))
 
-    def !==(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]      = NotEqual(lhs, rhs)
-    def >(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]        = GreaterThan(lhs, rhs)
-    def >(rhs: O)(using Ordering[O], LiteralShow[O]): Expr[I, Boolean] = GreaterThan(lhs, Literal(rhs))
+    def !==(rhs: Expr[O])(using Ordering[O]): Expr[Boolean]           = NotEqual(lhs, rhs)
+    def !==(rhs: O)(using Ordering[O], LiteralShow[O]): Expr[Boolean] = NotEqual(lhs, Literal(rhs))
+    def >(rhs: Expr[O])(using Ordering[O]): Expr[Boolean]             = GreaterThan(lhs, rhs)
+    def >(rhs: O)(using Ordering[O], LiteralShow[O]): Expr[Boolean]   = GreaterThan(lhs, Literal(rhs))
 
-    def >=(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]        = GreaterThanEqual(lhs, rhs)
-    def >=(rhs: O)(using Ordering[O], LiteralShow[O]): Expr[I, Boolean] = GreaterThanEqual(lhs, Literal(rhs))
-    def <(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]         = LessThan(lhs, rhs)
-    def <=(rhs: Expr[I, O])(using Ordering[O]): Expr[I, Boolean]        = LessThanEqual(lhs, rhs)
+    def >=(rhs: Expr[O])(using Ordering[O]): Expr[Boolean]           = GreaterThanEqual(lhs, rhs)
+    def >=(rhs: O)(using Ordering[O], LiteralShow[O]): Expr[Boolean] = GreaterThanEqual(lhs, Literal(rhs))
+    def <(rhs: Expr[O])(using Ordering[O]): Expr[Boolean]            = LessThan(lhs, rhs)
+    def <(rhs: O)(using Ordering[O], LiteralShow[O]): Expr[Boolean]  = LessThan(lhs, Literal(rhs))
+    def <=(rhs: Expr[O])(using Ordering[O]): Expr[Boolean]           = LessThanEqual(lhs, rhs)
+    def <=(rhs: O)(using Ordering[O], LiteralShow[O]): Expr[Boolean] = LessThanEqual(lhs, Literal(rhs))
 
-    def +(rhs: Expr[I, O])(using Numeric[O]): Expr[I, O] = Plus(lhs, rhs)
-    def -(rhs: Expr[I, O])(using Numeric[O]): Expr[I, O] = Minus(lhs, rhs)
-    def *(rhs: Expr[I, O])(using Numeric[O]): Expr[I, O] = Multiply(lhs, rhs)
+    def +(rhs: Expr[O])(using Numeric[O]): Expr[O]           = Plus(lhs, rhs)
+    def +(rhs: O)(using Numeric[O], LiteralShow[O]): Expr[O] = Plus(lhs, Literal(rhs))
+    def -(rhs: Expr[O])(using Numeric[O]): Expr[O]           = Minus(lhs, rhs)
+    def -(rhs: O)(using Numeric[O], LiteralShow[O]): Expr[O] = Minus(lhs, Literal(rhs))
+    def *(rhs: Expr[O])(using Numeric[O]): Expr[O]           = Multiply(lhs, rhs)
+    def *(rhs: O)(using Numeric[O], LiteralShow[O]): Expr[O] = Multiply(lhs, Literal(rhs))
 
-    def between(lowerBound: Expr[I, O], upperBound: Expr[I, O])(using Ordering[O]): Expr[I, Boolean] = Between(lhs, lowerBound, upperBound)
+    def between(lowerBound: Expr[O], upperBound: Expr[O])(using Ordering[O]): Expr[Boolean] = Between(lhs, lowerBound, upperBound)
 
-    infix def in(rhs: UnaryTest[O]): Expr[I, Boolean] = In(lhs, rhs)
+    infix def in(rhs: UnaryTest[O]): Expr[Boolean] = In(lhs, rhs)
   }
 
-  extension [I](lhs: Expr[I, Boolean]) {
-    def &&(rhs: Expr[I, Boolean]): Expr[I, Boolean]        = And(lhs, rhs)
-    infix def and(rhs: Expr[I, Boolean]): Expr[I, Boolean] = And(lhs, rhs)
-    def ||(rhs: Expr[I, Boolean]): Expr[I, Boolean]        = Or(lhs, rhs)
-    infix def or(rhs: Expr[I, Boolean]): Expr[I, Boolean]  = Or(lhs, rhs)
+  extension [I](lhs: Expr[Boolean]) {
+    def &&(rhs: Expr[Boolean]): Expr[Boolean]        = And(lhs, rhs)
+    infix def and(rhs: Expr[Boolean]): Expr[Boolean] = And(lhs, rhs)
+    def ||(rhs: Expr[Boolean]): Expr[Boolean]        = Or(lhs, rhs)
+    infix def or(rhs: Expr[Boolean]): Expr[Boolean]  = Or(lhs, rhs)
   }
 
 }

--- a/decisions4s-core/src/main/scala/decisions4s/HKD.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/HKD.scala
@@ -62,11 +62,12 @@ object HKD {
     var index = 0;
     hkd.pure(
       [t] =>
-        () => {
-          val name = hkd.fieldNames(index)
-          index += 1
-          name
-      },
+        () =>
+          {
+            val name = hkd.fieldNames(index)
+            index += 1
+            name
+          },
     )
   }
 

--- a/decisions4s-core/src/main/scala/decisions4s/Rule.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/Rule.scala
@@ -11,7 +11,7 @@ case class Rule[Input[_[_]]: HKD, Output[_[_]]: HKD](
 ) {
 
   def evaluateOutput()(using EvaluationContext[Input]): Output[Value] = {
-    val evaluate: OutputExpr[Input] ~> Value = [t] => expr => expr.evaluate(())
+    val evaluate: OutputExpr[Input] ~> Value = [t] => expr => expr.evaluate
     output.mapK(evaluate)
   }
 
@@ -25,7 +25,7 @@ case class Rule[Input[_[_]]: HKD, Output[_[_]]: HKD](
 
   def render(): (Input[Description], Output[Description]) = {
     given EvaluationContext[Input] = new EvaluationContext[Input] {
-      override val wholeInput: Input[ValueExpr] = HKD.typedNames[Input].mapK([t] => name => VariableStub[t](name))
+      override val wholeInput: Input[Expr] = HKD.typedNames[Input].mapK([t] => name => VariableStub[t](name))
     }
     (
       matching.mapK([t] => expr => expr.renderExpression),

--- a/decisions4s-core/src/main/scala/decisions4s/exprs/base.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/exprs/base.scala
@@ -2,18 +2,13 @@ package decisions4s.exprs
 
 import decisions4s.{Expr, LiteralShow}
 
-case class Literal[T](v: T)(using show: LiteralShow[T]) extends Expr[Any, T] {
-  override def evaluate(in: Any): T     = v
+case class Literal[T](v: T)(using show: LiteralShow[T]) extends Expr[T] {
+  override def evaluate: T              = v
   override def renderExpression: String = show.show(v)
 }
 
-case class Input[T]() extends Expr[T, T] {
-  override def evaluate(in: T): T       = in
-  override def renderExpression: String = "?"
-}
-
-case class Comment[I, O](inner: Expr[I, O], comment: String) extends Expr[I, O] {
-  override def evaluate(in: I): O = inner.evaluate(in)
+case class Comment[O](inner: Expr[O], comment: String) extends Expr[O] {
+  override def evaluate: O = inner.evaluate
 
   override def renderExpression: String = {
     val lines              = comment.linesIterator.toList
@@ -25,14 +20,13 @@ case class Comment[I, O](inner: Expr[I, O], comment: String) extends Expr[I, O] 
   }
 }
 
-case class Variable[T](name: String, value: T) extends Expr[Any, T] {
-  override def evaluate(in: Any): T = value
+case class Variable[T](name: String, value: T) extends Expr[T] {
+  override def evaluate: T              = value
   override def renderExpression: String = name
 }
 
 // used only for rendering
-case class VariableStub[T](name: String) extends Expr[Any, T] {
-  override def evaluate(in: Any): T = ???
+case class VariableStub[T](name: String) extends Expr[T] {
+  override def evaluate: T              = ???
   override def renderExpression: String = name
 }
-

--- a/decisions4s-core/src/main/scala/decisions4s/exprs/bool.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/exprs/bool.scala
@@ -6,62 +6,67 @@ import scala.math.Ordered.orderingToOrdered
 
 // https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-boolean-expressions/
 
-case class Equal[I, O](a: Expr[I, O], b: Expr[I, O]) extends Expr[I, Boolean] {
-  override def evaluate(in: I): Boolean     = a.evaluate(in) == b.evaluate(in)
+case class Equal[O](a: Expr[O], b: Expr[O]) extends Expr[Boolean] {
+  override def evaluate: Boolean        = a.evaluate == b.evaluate
   override def renderExpression: String = s"${a.renderExpression} = ${b.renderExpression}"
 }
 
-case class NotEqual[I, O](a: Expr[I, O], b: Expr[I, O]) extends Expr[I, Boolean] {
-  override def evaluate(in: I): Boolean     = a.evaluate(in) != b.evaluate(in)
+case class NotEqual[O](a: Expr[O], b: Expr[O]) extends Expr[Boolean] {
+  override def evaluate: Boolean        = a.evaluate != b.evaluate
   override def renderExpression: String = s"${a.renderExpression} != ${b.renderExpression}"
 }
 
-case class LessThan[I, O: Ordering](a: Expr[I, O], b: Expr[I, O])                                   extends Expr[I, Boolean] {
-  override def evaluate(in: I): Boolean     = a.evaluate(in) < b.evaluate(in)
+case class LessThan[O: Ordering](a: Expr[O], b: Expr[O])                                extends Expr[Boolean] {
+  override def evaluate: Boolean        = a.evaluate < b.evaluate
   override def renderExpression: String = s"${a.renderExpression} < ${b.renderExpression}"
 }
-case class LessThanEqual[I, O: Ordering](a: Expr[I, O], b: Expr[I, O])                              extends Expr[I, Boolean] {
-  override def evaluate(in: I): Boolean     = a.evaluate(in) <= b.evaluate(in)
+case class LessThanEqual[O: Ordering](a: Expr[O], b: Expr[O])                           extends Expr[Boolean] {
+  override def evaluate: Boolean        = a.evaluate <= b.evaluate
   override def renderExpression: String = s"${a.renderExpression} <= ${b.renderExpression}"
 }
-case class GreaterThan[I, O: Ordering](a: Expr[I, O], b: Expr[I, O])                                 extends Expr[I, Boolean] {
-  override def evaluate(in: I): Boolean     = a.evaluate(in) > b.evaluate(in)
+case class GreaterThan[O: Ordering](a: Expr[O], b: Expr[O])                             extends Expr[Boolean] {
+  override def evaluate: Boolean        = a.evaluate > b.evaluate
   override def renderExpression: String = s"${a.renderExpression} > ${b.renderExpression}"
 }
-case class GreaterThanEqual[I, O: Ordering](a: Expr[I, O], b: Expr[I, O])                            extends Expr[I, Boolean] {
-  override def evaluate(in: I): Boolean     = a.evaluate(in) >= b.evaluate(in)
+case class GreaterThanEqual[O: Ordering](a: Expr[O], b: Expr[O])                        extends Expr[Boolean] {
+  override def evaluate: Boolean        = a.evaluate >= b.evaluate
   override def renderExpression: String = s"${a.renderExpression} >= ${b.renderExpression}"
 }
-case class Between[I, O: Ordering](arg: Expr[I, O], lowerBound: Expr[I, O], upperBound: Expr[I, O]) extends Expr[I, Boolean] {
-  override def evaluate(in: I): Boolean     = {
-    val argValue = arg.evaluate(in)
-    argValue >= lowerBound.evaluate(in) && argValue <= upperBound.evaluate(in)
+case class Between[O: Ordering](arg: Expr[O], lowerBound: Expr[O], upperBound: Expr[O]) extends Expr[Boolean] {
+  override def evaluate: Boolean        = {
+    val argValue = arg.evaluate
+    argValue >= lowerBound.evaluate && argValue <= upperBound.evaluate
   }
   override def renderExpression: String =
     s"${arg.renderExpression} between ${lowerBound.renderExpression} and ${upperBound.renderExpression}"
 }
 
-case object True extends Expr[Any, Boolean] {
-  override def evaluate(in: Any): Boolean   = true
+case object True extends Expr[Boolean] {
+  override def evaluate: Boolean        = true
   override def renderExpression: String = "true"
 }
 
-case object False extends Expr[Any, Boolean] {
-  override def evaluate(in: Any): Boolean   = false
+case object False extends Expr[Boolean] {
+  override def evaluate: Boolean        = false
   override def renderExpression: String = "false"
 }
 
-case class And[I](lhs: Expr[I, Boolean], rhs: Expr[I, Boolean]) extends Expr[I, Boolean] {
-  override def evaluate(in: I): Boolean     = lhs.evaluate(in) && rhs.evaluate(in)
+case class Not(expr: Expr[Boolean]) extends Expr[Boolean] {
+  override def evaluate: Boolean        = !expr.evaluate
+  override def renderExpression: String = s"!${expr}"
+}
+
+case class And[I](lhs: Expr[Boolean], rhs: Expr[Boolean]) extends Expr[Boolean] {
+  override def evaluate: Boolean        = lhs.evaluate && rhs.evaluate
   override def renderExpression: String = s"${lhs.renderExpression} and ${rhs.renderExpression}"
 }
 
-case class Or[I](lhs: Expr[I, Boolean], rhs: Expr[I, Boolean])  extends Expr[I, Boolean] {
-  override def evaluate(in: I): Boolean     = lhs.evaluate(in) || rhs.evaluate(in)
+case class Or[I](lhs: Expr[Boolean], rhs: Expr[Boolean]) extends Expr[Boolean] {
+  override def evaluate: Boolean        = lhs.evaluate || rhs.evaluate
   override def renderExpression: String = s"${lhs.renderExpression} or ${rhs.renderExpression}"
 }
 
-case class In[I, O](lhs: Expr[I, O], rhs: UnaryTest[O]) extends Expr[I, Boolean] {
-  override def evaluate(in: I): Boolean     = rhs.evaluate(lhs.evaluate(in))
+case class In[O](lhs: Expr[O], rhs: UnaryTest[O]) extends Expr[Boolean] {
+  override def evaluate: Boolean        = rhs.evaluate(lhs.evaluate)
   override def renderExpression: String = s"${lhs.renderExpression} in ${rhs.renderExpression}"
 }

--- a/decisions4s-core/src/main/scala/decisions4s/exprs/math.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/exprs/math.scala
@@ -4,19 +4,18 @@ import decisions4s.Expr
 
 // https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-numeric-expressions/
 
-
-class Plus[I, O](lhs: Expr[I, O], rhs: Expr[I, O])(using Numeric[O]) extends Expr[I, O] {
-  override def evaluate(in: I): O = Numeric[O].plus(lhs.evaluate(in), rhs.evaluate(in))
+class Plus[O](lhs: Expr[O], rhs: Expr[O])(using Numeric[O]) extends Expr[O] {
+  override def evaluate: O              = Numeric[O].plus(lhs.evaluate, rhs.evaluate)
   override def renderExpression: String = s"${lhs.renderExpression} + ${rhs.renderExpression}"
 }
 
-class Minus[I, O](lhs: Expr[I, O], rhs: Expr[I, O])(using Numeric[O]) extends Expr[I, O] {
-  override def evaluate(in: I): O = Numeric[O].minus(lhs.evaluate(in), rhs.evaluate(in))
+class Minus[I, O](lhs: Expr[O], rhs: Expr[O])(using Numeric[O]) extends Expr[O] {
+  override def evaluate: O              = Numeric[O].minus(lhs.evaluate, rhs.evaluate)
   override def renderExpression: String = s"${lhs.renderExpression} - ${rhs.renderExpression}"
 }
 
-class Multiply[I, O](lhs: Expr[I, O], rhs: Expr[I, O])(using Numeric[O]) extends Expr[I, O] {
-  override def evaluate(in: I): O = Numeric[O].times(lhs.evaluate(in), rhs.evaluate(in))
+class Multiply[O](lhs: Expr[O], rhs: Expr[O])(using Numeric[O]) extends Expr[O] {
+  override def evaluate: O              = Numeric[O].times(lhs.evaluate, rhs.evaluate)
   override def renderExpression: String = s"${lhs.renderExpression} * ${rhs.renderExpression}"
 }
 

--- a/decisions4s-core/src/main/scala/decisions4s/internal/DiagnosticsPrinter.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/internal/DiagnosticsPrinter.scala
@@ -11,7 +11,7 @@ class DiagnosticsPrinter[Input[_[_]], Output[_[_]], Out](r: EvalResult[Input, Ou
   private val inputNames: IndexedSeq[String]              = summon[HKD[Input]].fieldNames
   private val matchingExpressions: Vector[Vector[String]] = table.rules.toVector.map(rule => {
     given EvaluationContext[Input] = new EvaluationContext[Input] {
-      override val wholeInput: Input[ValueExpr] = HKD.typedNames[Input].mapK([t] => name => VariableStub[t](name))
+      override val wholeInput: Input[Expr] = HKD.typedNames[Input].mapK([t] => name => VariableStub[t](name))
     }
     HKDUtils.collectFields(rule.matching.mapK[Const[String]]([t] => expr => expr.renderExpression)).toVector
   })

--- a/decisions4s-core/src/main/scala/decisions4s/internal/HKDUtils.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/internal/HKDUtils.scala
@@ -13,7 +13,7 @@ object HKDUtils {
     val result = ListBuffer[T]()
     type Void[T] = Any
     val gatherName: Const[T] ~> Void = [t] => (fa: T) => result.append(fa)
-    val _                     = instance.mapK(gatherName)
+    val _                            = instance.mapK(gatherName)
     result.toList
   }
 

--- a/decisions4s-core/src/main/scala/decisions4s/it.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/it.scala
@@ -8,29 +8,29 @@ import scala.annotation.targetName
 // Syntax for defining predicates
 object it {
 
-  def value[T]: Expr[T, T] = Input()
+  def satisfies[T](f: Expr[T] => Expr[Boolean]): UnaryTest[T] = UnaryTest.WithValue(f)
 
   @targetName("equalsToOp")
-  def ===[T](value: T)(using LiteralShow[T]): UnaryTest[T]               = UnaryTest.EqualTo(Literal(value))
-  def equalsTo[T](value: T)(using LiteralShow[T]): UnaryTest[T]          = UnaryTest.EqualTo(Literal(value))
-  def equalsTo[T](value: Expr[T, T])(using LiteralShow[T]): UnaryTest[T] = UnaryTest.EqualTo(value)
+  def ===[T](value: T)(using LiteralShow[T]): UnaryTest[T]            = UnaryTest.EqualTo(Literal(value))
+  def equalsTo[T](value: T)(using LiteralShow[T]): UnaryTest[T]       = UnaryTest.EqualTo(Literal(value))
+  def equalsTo[T](value: Expr[T])(using LiteralShow[T]): UnaryTest[T] = UnaryTest.EqualTo(value)
 
-  def equalsAnyOf[T](values: T*)(using LiteralShow[T]): UnaryTest[T] = Or(values.map(it.equalsTo))
-  def equalsAnyOf[T](values: Expr[T, Iterable[T]]): UnaryTest[T]     = UnaryTest.OneOf(values)
+  def equalsAnyOf[T](values: T*)(using LiteralShow[T]): UnaryTest[T] = UnaryTest.Or(values.map(it.equalsTo))
+  def equalsAnyOf[T](values: Expr[Iterable[T]]): UnaryTest[T]        = UnaryTest.OneOf(values)
 
   def >[T](value: T)(using LiteralShow[T], Ordering[T]): UnaryTest[T]  = Compare(Compare.Sign.`>`, Literal(value))
-  def >[T](value: Expr[T, T])(using Ordering[T]): UnaryTest[T]         = Compare(Compare.Sign.`>`, value)
+  def >[T](value: Expr[T])(using Ordering[T]): UnaryTest[T]            = Compare(Compare.Sign.`>`, value)
   def >=[T](value: T)(using LiteralShow[T], Ordering[T]): UnaryTest[T] = Compare(Compare.Sign.`>=`, Literal(value))
-  def >=[T](value: Expr[T, T])(using Ordering[T]): UnaryTest[T]        = Compare(Compare.Sign.`>=`, value)
+  def >=[T](value: Expr[T])(using Ordering[T]): UnaryTest[T]           = Compare(Compare.Sign.`>=`, value)
 
   def <[T](value: T)(using LiteralShow[T], Ordering[T]): UnaryTest[T]  = Compare(Compare.Sign.`<`, Literal(value))
-  def <[T](value: Expr[T, T])(using Ordering[T]): UnaryTest[T]         = Compare(Compare.Sign.`<`, value)
+  def <[T](value: Expr[T])(using Ordering[T]): UnaryTest[T]            = Compare(Compare.Sign.`<`, value)
   def <=[T](value: T)(using LiteralShow[T], Ordering[T]): UnaryTest[T] = Compare(Compare.Sign.`<=`, Literal(value))
-  def <=[T](value: Expr[T, T])(using Ordering[T]): UnaryTest[T]        = Compare(Compare.Sign.`<=`, value)
+  def <=[T](value: Expr[T])(using Ordering[T]): UnaryTest[T]           = Compare(Compare.Sign.`<=`, value)
 
   def catchAll[T]: UnaryTest[T] = UnaryTest.CatchAll
 
-  def isTrue: Expr[Any, Boolean]  = True
+  def isTrue: Expr[Boolean]       = True
   def isFalse: UnaryTest[Boolean] = UnaryTest.EqualTo(Literal(false))
 
 //  def isOneOf[T](values: Iterable[T]): UnaryTest[Boolean] = UnaryTest.OneOf(values)

--- a/decisions4s-core/src/main/scala/decisions4s/package.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/package.scala
@@ -10,20 +10,19 @@ package object decisions4s {
   type Value[T]       = T
   type Description[T] = String
 
-  type ValueExpr[T]           = Expr[Any, T]
   type MatchingExpr[In[_[_]]] = [T] =>> EvaluationContext[In] ?=> UnaryTest[T]
 
   trait EvaluationContext[In[_[_]]] {
-    def wholeInput: In[ValueExpr]
+    def wholeInput: In[Expr]
   }
 
-  type OutputExpr[In[_[_]]]                  = [T] =>> EvaluationContext[In] ?=> OutputValue[T]
-  opaque type OutputValue[T] <: Expr[Any, T] = Expr[Any, T]
+  type OutputExpr[In[_[_]]]             = [T] =>> EvaluationContext[In] ?=> OutputValue[T]
+  opaque type OutputValue[T] <: Expr[T] = Expr[T]
   object OutputValue {
     implicit def toLiteral[T](t: T)(using LiteralShow[T]): OutputValue[T] = Literal(t)
-    implicit def fromExpr[T](expr: Expr[Any, T]): OutputValue[T]          = expr
+    implicit def fromExpr[T](expr: Expr[T]): OutputValue[T]               = expr
   }
 
-  def wholeInput[In[_[_]]](using ec: EvaluationContext[In]): In[ValueExpr] = ec.wholeInput
+  def wholeInput[In[_[_]]](using ec: EvaluationContext[In]): In[Expr] = ec.wholeInput
 
 }

--- a/decisions4s-core/src/test/scala/decisions4s/DecisionTableTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/DecisionTableTest.scala
@@ -192,7 +192,7 @@ class DecisionTableTest extends AnyFreeSpec {
 
   def rawResults(hits: Boolean*): List[RuleResult[Input, Output]] = {
     given EvaluationContext[Input] = new EvaluationContext[Input] {
-      override def wholeInput: Input[ValueExpr] = null // variables not sued in those tests
+      override def wholeInput: Input[Expr] = null // variables not sued in those tests
     }
 
     hits.zipWithIndex

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/InputTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/InputTest.scala
@@ -6,7 +6,7 @@ import munit.FunSuite
 
 class InputTest extends FunSuite {
   test("basic") {
-    checkUnaryExpression(it.value[Int] === Literal(1), 1, true)
-    checkUnaryExpression(it.value[Int] === Literal(1), 2, false)
+    checkUnaryExpression(it.satisfies[Int](_ === Literal(1)), 1, true)
+    checkUnaryExpression(it.satisfies[Int](_ === Literal(1)), 2, false)
   }
 }

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/LiteralTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/LiteralTest.scala
@@ -30,8 +30,8 @@ class LiteralTest extends FunSuite {
     checkLiteralAdj(Period.ofDays(12))(x => Duration.ofHours(x.getDays * 24)) // period below 1 month is parsed as duration
     checkLiteral(Period.ofMonths(2))
 
-    checkLiteral(List(1,2,3))
-    checkLiteral(Vector(1,2,3))
+    checkLiteral(List(1, 2, 3))
+    checkLiteral(Vector(1, 2, 3))
 
     // context is currently unsupported
     // https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-data-types/#context

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/TestUtils.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/TestUtils.scala
@@ -25,13 +25,13 @@ object TestUtils {
   }
 
   def checkExpression[T](
-      expr: Expr[Any, T],
+      expr: Expr[T],
       expectedEvalResult: T,
       expectedParseResult: Option[Any] = None,
       expectedFeelExpr: String = null,
   ): Unit = {
     import munit.Assertions.*
-    assert(clue(expr.evaluate(())) == clue(expectedEvalResult))
+    assert(clue(expr.evaluate == clue(expectedEvalResult)))
 
     val feelExpression = clue(expr.renderExpression)
 

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/TrueTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/TrueTest.scala
@@ -4,7 +4,7 @@ import decisions4s.exprs.TestUtils.checkExpression
 import munit.FunSuite
 
 class TrueTest extends FunSuite {
-  test("true"){
+  test("true") {
     checkExpression(True, true)
   }
 }

--- a/decisions4s-core/src/test/scala/decisions4s/exprs/UnaryTestTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/exprs/UnaryTestTest.scala
@@ -8,20 +8,21 @@ import munit.FunSuite
 class UnaryTestTest extends FunSuite {
 
   test("bool conversion") {
-    val bool1: Expr[Int, Boolean]  = it.value[Int] > 1
+    val bool1: Expr[Boolean]   = Literal(1) > 0
     val unary1: UnaryTest[Int] = bool1
     checkUnaryExpression(unary1, 2, true)
-    checkUnaryExpression(unary1, 1, false)
   }
 
   test("comparison with boolean") {
     checkUnaryExpression(UnaryTest.EqualTo(True), false, false)
-    checkUnaryExpression((True: UnaryTest[Boolean]), true, true)
+    checkUnaryExpression(True: UnaryTest[Boolean], true, true)
+    checkUnaryExpression(UnaryTest.EqualTo(False), false, true)
+    checkUnaryExpression(False: UnaryTest[Boolean], true, false)
   }
 
   test("list conversion") {
-    val list: Expr[Int, List[Int]] = Literal(List(1, 2, 3))
-    val unary: UnaryTest[Int]      = it.equalsAnyOf(list)
+    val list: Expr[List[Int]] = Literal(List(1, 2, 3))
+    val unary: UnaryTest[Int] = it.equalsAnyOf(list)
     checkUnaryExpression(unary, 1, true)
     checkUnaryExpression(it.equalsAnyOf(1, 2, 3), 1, true)
     checkUnaryExpression(unary, 2, true)
@@ -30,7 +31,7 @@ class UnaryTestTest extends FunSuite {
     checkUnaryExpression(it.equalsAnyOf(1, 2, 3), 4, false)
   }
   test("value conversion") {
-    val value: Expr[Int, Int] = Literal(1)
+    val value: Expr[Int]      = Literal(1)
     val unary: UnaryTest[Int] = it.equalsTo(value)
     checkUnaryExpression(unary, 1, true)
     checkUnaryExpression(it === 1, 1, true)
@@ -72,7 +73,7 @@ class UnaryTestTest extends FunSuite {
     checkUnaryExpression(Not(Or(Seq(it.equalsTo(1), it.equalsTo(2)))), 2, false)
     checkUnaryExpression(Not(Or(Seq(it.equalsTo(1), it.equalsTo(2)))), 3, true)
 
-    checkUnaryExpression(! (it > 1), 2, false)
+    checkUnaryExpression(!(it > 1), 2, false)
   }
 
 }

--- a/decisions4s-dmn-to-image/src/test/scala/decisions4s/dmn/image/ImageComparison.scala
+++ b/decisions4s-dmn-to-image/src/test/scala/decisions4s/dmn/image/ImageComparison.scala
@@ -15,9 +15,9 @@ object ImageComparison {
   }
 
   private def getDifferencePercent(img1: BufferedImage, img2: BufferedImage): Double = {
-    val width = img1.getWidth
+    val width  = img1.getWidth
     val height = img1.getHeight
-    var diff = 0L
+    var diff   = 0L
 
     for (y <- 0 until height) {
       for (x <- 0 until width) {

--- a/decisions4s-examples/src/main/scala/decisions4s/example/checks/ElderlyScamCheckDecision.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/checks/ElderlyScamCheckDecision.scala
@@ -13,7 +13,7 @@ object ElderlyScamCheckDecision {
     DecisionTable(
       rules,
       name = "ElderlyScamCheck",
-      HitPolicy.Single
+      HitPolicy.Single,
     )
 
   private type Rule = decisions4s.Rule[Input, Output]

--- a/decisions4s-examples/src/main/scala/decisions4s/example/docs/DiagnosticsExample.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/docs/DiagnosticsExample.scala
@@ -1,6 +1,5 @@
 package decisions4s.example.docs
 
-
 object DiagnosticsExample {
 
   import decisions4s.HKD

--- a/decisions4s-examples/src/main/scala/decisions4s/example/docs/EffectfulEvalExample.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/docs/EffectfulEvalExample.scala
@@ -12,7 +12,7 @@ object EffectfulEvalExample {
   import decisions4s.cats.effect.*
 
   val decisionTable: DecisionTable[Input, Output, HitPolicy.First] = ???
-  val input: Input[IO] = ???
+  val input: Input[IO]                                             = ???
 
   decisionTable.evaluateFirstF(input).map(_.output)
   // end_effect

--- a/decisions4s-examples/src/main/scala/decisions4s/example/docs/ExpressionsExample.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/docs/ExpressionsExample.scala
@@ -1,7 +1,7 @@
 package decisions4s.example.docs
 
 import decisions4s.Expr
-import decisions4s.exprs.UnaryTest
+import decisions4s.exprs.{Literal, UnaryTest}
 
 object ExpressionsExample {
 
@@ -9,23 +9,16 @@ object ExpressionsExample {
   import decisions4s.it
   val lowerThan5: UnaryTest[Int]  = it < 5
   val equalFoo: UnaryTest[String] = it.equalsTo("foo")
-  val complex: Expr[Int, Boolean] = it > 1 && it < 5
+  val complex: UnaryTest[Int]     = it.satisfies(v => v > 1 && v < 5)
   // end_expr
 
   // start_custom_generic
-  class EndsWithFoo[In](argument: Expr[In, String]) extends Expr[In, Boolean] {
-    override def evaluate(in: In): Boolean = argument.evaluate(in).endsWith("foo")
-    override def renderExpression: String  = s"endsWithFoo(${argument.renderExpression})"
+  case class EndsWithFoo(argument: Expr[String]) extends Expr[Boolean] {
+    override def evaluate: Boolean        = argument.evaluate.endsWith("foo")
+    override def renderExpression: String = s"endsWithFoo(${argument.renderExpression})"
   }
-  val endsWithFoo: EndsWithFoo[String] = EndsWithFoo(it.value)
+  val endsWithFoo: UnaryTest[String] = it.satisfies(EndsWithFoo.apply)
+  val endsWithFoo2: Expr[Boolean] = EndsWithFoo(Literal("myfoo"))
   // end_custom_generic
-
-  // start_custom_simplified
-  class EndsWithFooSimple extends Expr[String, Boolean] {
-    override def evaluate(in: String): Boolean = in.endsWith("foo")
-    override def renderExpression: String  = s"endsWithFoo()"
-  }
-  val endsWithFooSimple: EndsWithFoo[String] = EndsWithFoo(it.value)
-  // end_custom_simplified
 
 }

--- a/decisions4s-examples/src/main/scala/decisions4s/example/docs/HitPoliciesExample.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/docs/HitPoliciesExample.scala
@@ -1,6 +1,5 @@
 package decisions4s.example.docs
 
-
 object HitPoliciesExample {
 
   import decisions4s.HKD

--- a/decisions4s-examples/src/main/scala/decisions4s/example/provider_routing/BankingProviderDecision.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/provider_routing/BankingProviderDecision.scala
@@ -20,7 +20,7 @@ object BankingProviderDecision {
   private lazy val rules: List[Rule] = List(
     Rule(
       matching = Input(
-        userResidenceCountry = IsEEA,
+        userResidenceCountry = it.satisfies(IsEEA.apply),
         currency = it.catchAll,
       ),
       output = Output(

--- a/decisions4s-examples/src/main/scala/decisions4s/example/provider_routing/exprs.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/provider_routing/exprs.scala
@@ -2,10 +2,13 @@ package decisions4s.example.provider_routing
 
 import decisions4s.Expr
 
-object IsEEA extends Expr[Country, Boolean] {
+case class IsEEA(arg: Expr[Country]) extends Expr[Boolean] {
+
+  override def evaluate: Boolean = IsEEA.eeaCountries.contains(arg.evaluate)
+
+  override def renderExpression: String = s"isEEA(${arg.renderExpression})"
+}
+
+object IsEEA {
   val eeaCountries: Set[Country] = Set(Country("PL"), Country("CH"))
-
-  override def evaluate(in: Country): Boolean = IsEEA.eeaCountries.contains(in)
-
-  override def renderExpression: String = s"isEEA(?)"
 }

--- a/decisions4s-examples/src/main/scala/decisions4s/example/provider_routing/model.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/provider_routing/model.scala
@@ -7,9 +7,9 @@ case class Country(alpha2: String)
 case class Currency(code: String)
 
 object Currency {
-  def EUR: Currency        = Currency("EUR")
-  def PLN: Currency        = Currency("PLN")
-  def CHF: Currency        = Currency("CHF")
+  def EUR: Currency           = Currency("EUR")
+  def PLN: Currency           = Currency("PLN")
+  def CHF: Currency           = Currency("CHF")
   given LiteralShow[Currency] = _.code
 }
 

--- a/decisions4s-examples/src/test/scala/decisions4s/example/checks/ElderlyScamCheckDecisionTest.scala
+++ b/decisions4s-examples/src/test/scala/decisions4s/example/checks/ElderlyScamCheckDecisionTest.scala
@@ -6,11 +6,7 @@ import org.scalatest.freespec.AnyFreeSpec
 
 import java.io.File
 
-class ElderlyScamCheckDecisionTest extends AnyFreeSpec  {
-
-  "evaluate" - {
-
-  }
+class ElderlyScamCheckDecisionTest extends AnyFreeSpec {
 
   "render dmn" in {
     val dmnInstance = DmnConverter.convert(ElderlyScamCheckDecision.decisionTable)

--- a/decisions4s-examples/src/test/scala/decisions4s/example/checks/TotalWealthCheckDecisionTest.scala
+++ b/decisions4s-examples/src/test/scala/decisions4s/example/checks/TotalWealthCheckDecisionTest.scala
@@ -6,11 +6,7 @@ import org.scalatest.freespec.AnyFreeSpec
 
 import java.io.File
 
-class TotalWealthCheckDecisionTest extends AnyFreeSpec  {
-
-  "evaluate" - {
-
-  }
+class TotalWealthCheckDecisionTest extends AnyFreeSpec {
 
   "render dmn" in {
     val dmnInstance = DmnConverter.convert(TotalWealthCheckDecision.decisionTable)

--- a/decisions4s-examples/src/test/scala/decisions4s/example/provider_routing/BankingProviderDecisionTest.scala
+++ b/decisions4s-examples/src/test/scala/decisions4s/example/provider_routing/BankingProviderDecisionTest.scala
@@ -13,21 +13,25 @@ class BankingProviderDecisionTest extends AnyFreeSpec {
   "evaluate" - {
 
     "from eea to foo inc" in {
-      val result = BankingProviderDecision.decisionTable.evaluateFirst(
-        Input[Value](
-          userResidenceCountry = IsEEA.eeaCountries.head,
-          currency = Currency("PLN"),
-        ),
-      ).output
+      val result = BankingProviderDecision.decisionTable
+        .evaluateFirst(
+          Input[Value](
+            userResidenceCountry = IsEEA.eeaCountries.head,
+            currency = Currency("PLN"),
+          ),
+        )
+        .output
       assert(result.get.provider == Provider.FooInc)
     }
     "from pln to foo inc" in {
-      val result = BankingProviderDecision.decisionTable.evaluateFirst(
-        Input[Value](
-          userResidenceCountry = Country("XXX"),
-          currency = Currency.PLN,
-        ),
-      ).output
+      val result = BankingProviderDecision.decisionTable
+        .evaluateFirst(
+          Input[Value](
+            userResidenceCountry = Country("XXX"),
+            currency = Currency.PLN,
+          ),
+        )
+        .output
       assert(result.get.provider == Provider.BarLtd)
     }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("com.github.sbt" % "sbt-dynver"     % "5.0.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("org.typelevel"  % "sbt-tpolecat"   % "0.5.0")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.4.6")

--- a/website/docs/features/rules.md
+++ b/website/docs/features/rules.md
@@ -8,17 +8,16 @@ sidebar_position: 3
 Each rule has two parts: matching on the input and producing the output, both of which are defined using
 expressions.
 
-Expression is just an object that can produce given `Out` based on `In` and statically render its string representation.
+Expression is just an object that can produce given `Out` and render its string representation.
 
 ```scala 
-trait Expr[-In, +Out] {
-  def evaluate(in: In): Out
-
+trait Expr[+Out] {
+  def evaluate: Out
   def renderExpression: String
 }
 ```
 
-There is also a specialised type `UnaryTest[In] extends Expr[In, Boolean]` that allows us to closely follow
+There is also a specialised type `UnaryTest[In]` that allows us to loosely follow
 the [FEEL model](https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-unary-tests/). This could be
 considered an internal complexity of the library, but all the matching logic has to be of type `UnaryTest[T]`.
 
@@ -32,7 +31,7 @@ case class Rule[Input[_[_]], Output[_[_]]](
 <!-- @formatter:on -->
 
 All the most common ways of building `UnaryTest`s are accesisble through `it` object.
-Implicit conversion between `Expr[T, Boolean]` is also defined.
+Implicit conversion between `Expr[Boolean]` is also defined.
 
 ## Built-in Expressions
 
@@ -48,13 +47,6 @@ To define a custom expression its enough to extend `Expr` trait.
 
 ```scala file=./main/scala/decisions4s/example/docs/ExpressionsExample.scala start=start_custom_generic end=end_custom_generic
 ```
-
-The same can be simplified if it needs to be applied only to the input of the rule, not to any expression.
-
-```scala file=./main/scala/decisions4s/example/docs/ExpressionsExample.scala start=start_custom_simplified end=end_custom_simplified
-```
-
-The downside is that rendered form might not be clear to the reader
 
 ## FEEL Compatibility
 


### PR DESCRIPTION
In the initial design, input was incorporated into `Expr` due to the bias toward `UnaryTest` - primary usage of expressions was matching logic that has to be an unary test. 

Turned out this was poor design choice as `Expr` should be its own thing, and as such, it doesn't make sense for it to accept input.