### PR TITLE
Fix DmnToImageConverter when used as dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import org.typelevel.scalacoptions.ScalacOptions
-import sbt.Keys.localStaging
 
 lazy val `decisions4s` = (project in file("."))
   .settings(commonSettings)
@@ -59,7 +58,7 @@ lazy val `decisions4s-examples` = (project in file("decisions4s-examples"))
   )
   .dependsOn(`decisions4s-core`, `decisions4s-dmn`, `decisions4s-cats-effect`, `decisions4s-dmn-to-image`)
 
-lazy val `decisions4s-examples-scala2` = (project in file("decisions4s-examples-scala-2"))
+lazy val `decisions4s-examples-scala2` = (project in file("decisions4s-examples-scala2"))
   .settings(
     scalaVersion   := "2.13.16",
     libraryDependencies ++= testDeps,

--- a/decisions4s-dmn-to-image/src/main/scala/decisions4s/dmn/image/DmnToImageConverter.scala
+++ b/decisions4s-dmn-to-image/src/main/scala/decisions4s/dmn/image/DmnToImageConverter.scala
@@ -17,6 +17,8 @@ class DmnToImageConverter(customDriver: Option[WebDriver & JavascriptExecutor & 
   private val (driver, shouldClose): (WebDriver & JavascriptExecutor & TakesScreenshot, Boolean) =
     customDriver.map(_ -> false).getOrElse(createDefaultDriver() -> true)
 
+  private lazy val webBundle: WebBundle = WebBundle.fromResources("generated-web-bundle")
+
   def convertDiagram(dmnXml: String): Try[IArray[Byte]] = Try {
     openSkeleton()
     loadDmn(dmnXml)
@@ -25,7 +27,7 @@ class DmnToImageConverter(customDriver: Option[WebDriver & JavascriptExecutor & 
 
   private def openSkeleton(): Unit = {
     // Load the bundled HTML
-    val url  = getClass.getResource("/generated-web-bundle/index.html").toString
+    val url  = webBundle.indexHtmlUri.toString
     driver.get(url)
     // Wait until the page is loaded
     val wait = new WebDriverWait(driver, Duration.ofSeconds(10))
@@ -65,6 +67,7 @@ class DmnToImageConverter(customDriver: Option[WebDriver & JavascriptExecutor & 
     options.addArguments("--allow-file-access-from-files")
     new ChromeDriver(options)
   }
+
 
   override def close(): Unit = if (shouldClose) driver.quit()
 }

--- a/decisions4s-dmn-to-image/src/main/scala/decisions4s/dmn/image/DmnToImageConverter.scala
+++ b/decisions4s-dmn-to-image/src/main/scala/decisions4s/dmn/image/DmnToImageConverter.scala
@@ -68,6 +68,5 @@ class DmnToImageConverter(customDriver: Option[WebDriver & JavascriptExecutor & 
     new ChromeDriver(options)
   }
 
-
   override def close(): Unit = if (shouldClose) driver.quit()
 }

--- a/decisions4s-dmn-to-image/src/main/scala/decisions4s/dmn/image/WebBundle.scala
+++ b/decisions4s-dmn-to-image/src/main/scala/decisions4s/dmn/image/WebBundle.scala
@@ -1,0 +1,64 @@
+package decisions4s.dmn.image
+
+import java.net.URI
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileSystemNotFoundException, FileSystems, FileVisitResult, Files, Path, Paths, SimpleFileVisitor, StandardCopyOption}
+import java.util.Collections
+
+case class WebBundle(indexHtmlUri: URI)
+
+object WebBundle {
+
+  def fromResources(resourcePath: String, classLoader: ClassLoader = getClass.getClassLoader): WebBundle = {
+    val temp = Files.createTempDirectory("dmn-web-bundle")
+    temp.toFile.deleteOnExit()
+    copyFromResource(resourcePath, temp, classLoader)
+    val url  = temp.resolve("index.html").toUri
+    WebBundle(url)
+  }
+
+  /** Copy a directory (and all sub‐entries) out of the JAR into `target` */
+  private def copyFromResource(source: String, target: Path, classLoader: ClassLoader): Unit = {
+    // Grab a URI pointing into the JAR
+    val sourcePath = classLoader.getResource(source).toURI
+    withPath(sourcePath) { jarPath =>
+      val _ = Files.walkFileTree(
+        jarPath,
+        new SimpleFileVisitor[Path]() {
+          override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
+            val rel = jarPath.relativize(dir).toString
+            Files.createDirectories(target.resolve(rel))
+            FileVisitResult.CONTINUE
+          }
+
+          override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+            val rel = jarPath.relativize(file).toString
+            Files.copy(file, target.resolve(rel), StandardCopyOption.REPLACE_EXISTING)
+            FileVisitResult.CONTINUE
+          }
+        },
+      )
+    }
+  }
+
+  private def withPath[T](resPath: URI)(thunk: Path => T): T = {
+    val (effectivePath, fsOpt) =
+      try {
+        // Direct file-system path (IDE or exploded resources)
+        (Paths.get(resPath), None)
+      } catch {
+        case _: FileSystemNotFoundException =>
+          // Resource inside a JAR: mount a new FileSystem
+          val fs   = FileSystems.newFileSystem(resPath, Collections.emptyMap[String, String]())
+          val path = fs.provider().getPath(resPath)
+          (path, Some(fs))
+      }
+
+    try {
+      thunk(effectivePath)
+    } finally {
+      fsOpt.foreach(_.close())
+    }
+  }
+
+}

--- a/decisions4s-dmn-to-image/src/test/scala/decisions4s/dmn/image/WebBundleTest.scala
+++ b/decisions4s-dmn-to-image/src/test/scala/decisions4s/dmn/image/WebBundleTest.scala
@@ -7,11 +7,10 @@ import java.net.URLClassLoader
 import java.nio.file.{Files, Path}
 import java.util.jar.{JarEntry, JarOutputStream}
 
-
 class WebBundleTest extends AnyFreeSpec {
 
   "unpack files from jar" in {
-    val jarFile = createTestJar()
+    val jarFile     = createTestJar()
     val classLoader = new URLClassLoader(Array(jarFile.toURI.toURL), this.getClass.getClassLoader)
 
     val webBundle = WebBundle.fromResources("test", classLoader)
@@ -44,5 +43,3 @@ class WebBundleTest extends AnyFreeSpec {
     jarFile
   }
 }
-
-

--- a/decisions4s-dmn-to-image/src/test/scala/decisions4s/dmn/image/WebBundleTest.scala
+++ b/decisions4s-dmn-to-image/src/test/scala/decisions4s/dmn/image/WebBundleTest.scala
@@ -1,0 +1,48 @@
+package decisions4s.dmn.image
+
+import org.scalatest.freespec.AnyFreeSpec
+
+import java.io.{File, FileOutputStream}
+import java.net.URLClassLoader
+import java.nio.file.{Files, Path}
+import java.util.jar.{JarEntry, JarOutputStream}
+
+
+class WebBundleTest extends AnyFreeSpec {
+
+  "unpack files from jar" in {
+    val jarFile = createTestJar()
+    val classLoader = new URLClassLoader(Array(jarFile.toURI.toURL), this.getClass.getClassLoader)
+
+    val webBundle = WebBundle.fromResources("test", classLoader)
+    assert(!webBundle.indexHtmlUri.toString.contains("jar"))
+    val extracted = Path.of(webBundle.indexHtmlUri)
+    assert(Files.exists(extracted))
+    assert(Files.readString(extracted).contains("Hello from test JAR"))
+  }
+
+  private def createTestJar(): File = {
+    val jarFile = File.createTempFile("webbundle-test", ".jar")
+    jarFile.deleteOnExit()
+
+    val jarOut = new JarOutputStream(new FileOutputStream(jarFile))
+    try {
+      def addEntry(pathInJar: String, content: Option[String] = None): Unit = {
+        val entry = new JarEntry(pathInJar)
+        entry.setTime(System.currentTimeMillis())
+        jarOut.putNextEntry(entry)
+        content.foreach { c => jarOut.write(c.getBytes("UTF-8")) }
+        jarOut.closeEntry()
+      }
+
+      addEntry("test/") // ← this is the missing directory entry
+      addEntry("test/index.html", Some("<html><body>Hello from test JAR</body></html>"))
+    } finally {
+      jarOut.close()
+    }
+
+    jarFile
+  }
+}
+
+


### PR DESCRIPTION
Files from jars are not accessible to selenium. 