### PR TITLE
Make `evaluateDistinct` require an explicit `Equiv` instance

### DIFF
--- a/decisions4s-core/src/main/scala/decisions4s/DecisionTable.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/DecisionTable.scala
@@ -27,7 +27,7 @@ object DecisionTable {
       transformer(dt, in).single()
   }
   extension [Input[_[_]], Output[_[_]]](dt: DecisionTable[Input, Output, HitPolicy.Distinct]) {
-    def evaluateDistinct(in: Input[Value]): EvalResult.Distinct[Input, Output] =
+    def evaluateDistinct(in: Input[Value])(using Equiv[Output[Value]]): EvalResult.Distinct[Input, Output] =
       transformer(dt, in).distinct()
   }
   extension [Input[_[_]], Output[_[_]]](dt: DecisionTable[Input, Output, HitPolicy.First]) {

--- a/decisions4s-core/src/main/scala/decisions4s/internal/EvaluationResultTransformer.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/internal/EvaluationResultTransformer.scala
@@ -20,8 +20,8 @@ class EvaluationResultTransformer[Input[_[_]], Output[_[_]]](
     }
   }
 
-  /** Returns result if there is a unique result produced by all satisfied rules. Equality is governed by the supplied [[Equiv]] instance,
-    * making the comparison rule explicit at the call site (e.g. to opt into bit-exact Double comparison via `doubleToRawLongBits`).
+  /** Returns result if there is a unique result produced by all satisfied rules. Equality is governed by the supplied [[Equiv]] instance, making the
+    * comparison rule explicit at the call site (e.g. to opt into bit-exact Double comparison via `doubleToRawLongBits`).
     */
   def distinct()(using eq: Equiv[Output[Value]]): EvalResult.Distinct[Input, Output] = {
     val raw              = rawResults.map(_.apply()).toList

--- a/decisions4s-core/src/main/scala/decisions4s/internal/EvaluationResultTransformer.scala
+++ b/decisions4s-core/src/main/scala/decisions4s/internal/EvaluationResultTransformer.scala
@@ -20,15 +20,18 @@ class EvaluationResultTransformer[Input[_[_]], Output[_[_]]](
     }
   }
 
-  /** Returns result if there is a unique result produced by all satisfied rules.
+  /** Returns result if there is a unique result produced by all satisfied rules. Equality is governed by the supplied [[Equiv]] instance,
+    * making the comparison rule explicit at the call site (e.g. to opt into bit-exact Double comparison via `doubleToRawLongBits`).
     */
-  def distinct(): EvalResult.Distinct[Input, Output] = {
+  def distinct()(using eq: Equiv[Output[Value]]): EvalResult.Distinct[Input, Output] = {
     val raw              = rawResults.map(_.apply()).toList
     val satisfiedResults = raw.flatMap(_.evaluationResult)
-
-    val distinct = satisfiedResults.toSet
-    if (distinct.size > 1) result(raw, Left("not-distinct"))
-    else result(raw, Right(distinct.headOption))
+    satisfiedResults match {
+      case Nil          => result(raw, Right(None))
+      case head :: tail =>
+        if (tail.forall(eq.equiv(_, head))) result(raw, Right(Some(head)))
+        else result(raw, Left("not-distinct"))
+    }
   }
 
   def first(): EvalResult.First[Input, Output] = {

--- a/decisions4s-core/src/test/scala/decisions4s/DecisionTableTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/DecisionTableTest.scala
@@ -48,6 +48,8 @@ class DecisionTableTest extends AnyFreeSpec {
 
   val anyTestTable: DecisionTable[Input, Output, HitPolicy.Distinct] = uniqueTestTable.copy(hitPolicy = HitPolicy.Distinct)
 
+  given Equiv[Output[Value]] = Equiv.universal
+
   "distinct - single matching rule" in {
     val result = anyTestTable.evaluateDistinct(Input(2))
     assert(result.output == Right(Some(Output[Value](1))))
@@ -73,6 +75,36 @@ class DecisionTableTest extends AnyFreeSpec {
     val result = anyTestTable.evaluateDistinct(input)
     assert(result.output == Left("not-distinct"))
     assert(result.results == rawResults(true, true, true))
+  }
+
+  "distinct - equality is customizable via Equiv (e.g. bit-exact Double)" in {
+    case class FloatInput[F[_]](trigger: F[Int]) derives HKD
+    case class FloatOutput[F[_]](value: F[Double]) derives HKD
+
+    val table: DecisionTable[FloatInput, FloatOutput, HitPolicy.Distinct] = DecisionTable(
+      rules = List(
+        Rule(matching = FloatInput(it > 0), output = FloatOutput(+0.0)),
+        Rule(matching = FloatInput(it > 0), output = FloatOutput(-0.0)),
+      ),
+      "float-distinct",
+      HitPolicy.Distinct,
+    )
+
+    // Universal Equiv uses ==; case-class equality on a Double field uses primitive ==,
+    // which treats +0.0 and -0.0 as the same value.
+    locally {
+      given Equiv[FloatOutput[Value]] = Equiv.universal
+      val result                      = table.evaluateDistinct(FloatInput(1))
+      assert(result.output == Right(Some(FloatOutput[Value](+0.0))))
+    }
+
+    // A user-supplied Equiv comparing raw bits flags +0.0 vs -0.0 as not-distinct.
+    locally {
+      given Equiv[FloatOutput[Value]] = (a, b) =>
+        java.lang.Double.doubleToRawLongBits(a.value) == java.lang.Double.doubleToRawLongBits(b.value)
+      val result                      = table.evaluateDistinct(FloatInput(1))
+      assert(result.output == Left("not-distinct"))
+    }
   }
 
   val firstTestTable: DecisionTable[Input, Output, HitPolicy.First] = uniqueTestTable.copy(hitPolicy = HitPolicy.First)

--- a/decisions4s-core/src/test/scala/decisions4s/DecisionTableTest.scala
+++ b/decisions4s-core/src/test/scala/decisions4s/DecisionTableTest.scala
@@ -100,8 +100,7 @@ class DecisionTableTest extends AnyFreeSpec {
 
     // A user-supplied Equiv comparing raw bits flags +0.0 vs -0.0 as not-distinct.
     locally {
-      given Equiv[FloatOutput[Value]] = (a, b) =>
-        java.lang.Double.doubleToRawLongBits(a.value) == java.lang.Double.doubleToRawLongBits(b.value)
+      given Equiv[FloatOutput[Value]] = (a, b) => java.lang.Double.doubleToRawLongBits(a.value) == java.lang.Double.doubleToRawLongBits(b.value)
       val result                      = table.evaluateDistinct(FloatInput(1))
       assert(result.output == Left("not-distinct"))
     }

--- a/decisions4s-examples/src/main/scala/decisions4s/example/docs/DiagnosticsExample.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/docs/DiagnosticsExample.scala
@@ -15,6 +15,7 @@ object DiagnosticsExample {
 
   val decisionTable: DecisionTable[Input, Output, HitPolicy.Distinct] = ???
   val input: Input[Value]                                             = ???
+  given Equiv[Output[Value]]                                          = Equiv.universal
 
   decisionTable.evaluateDistinct(input).makeDiagnosticsString
   // end_diagnose

--- a/decisions4s-examples/src/main/scala/decisions4s/example/docs/HitPoliciesExample.scala
+++ b/decisions4s-examples/src/main/scala/decisions4s/example/docs/HitPoliciesExample.scala
@@ -19,10 +19,13 @@ object HitPoliciesExample {
   single.evaluateSingle(in)
   // end_single
 
-  // start_distinct
-  val distinct: DecisionTable[In, Out, HitPolicy.Distinct] = DecisionTable(rules, name, HitPolicy.Distinct)
-  distinct.evaluateDistinct(in)
-  // end_distinct
+  {
+    // start_distinct
+    val distinct: DecisionTable[In, Out, HitPolicy.Distinct] = DecisionTable(rules, name, HitPolicy.Distinct)
+    given Equiv[Out[Value]]                                  = Equiv.universal
+    distinct.evaluateDistinct(in)
+    // end_distinct
+  }
 
   // start_first
   val first: DecisionTable[In, Out, HitPolicy.First] = DecisionTable(rules, name, HitPolicy.First)


### PR DESCRIPTION
Fix for #102 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Distinct hit policy evaluation now uses customizable equivalence logic for determining output distinctness rather than standard deduplication.

* **Tests**
  * Added test verifying custom equivalence behavior with floating-point comparison edge cases.

* **Documentation**
  * Updated examples demonstrating how to configure equivalence instances for distinct hit policy evaluations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/business4s/decisions4s/pull/105)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->